### PR TITLE
Fix instrumentation test apk path

### DIFF
--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -33,5 +33,5 @@ jobs:
         uses: minvws/AppCenter-Github-Action@v1.0.3
         if: ${{ env.APP_CENTER_TOKEN }}
         with:
-          command: appcenter test run espresso --app ${{env.APP_CENTER_APP}} --devices belastingdienst/vws-covid-19-notificatie-instrumentation-test --app-path app/build/outputs/apk/debug/covid-notificatie-debug.apk --test-series master --locale en_US --test-apk-path build/outputs/apk/androidTest/debug/covid-notificatie-debug-androidTest.apk
+          command: appcenter test run espresso --app ${{env.APP_CENTER_APP}} --devices belastingdienst/vws-covid-19-notificatie-instrumentation-test --app-path app/build/outputs/apk/debug/covid-notificatie-debug.apk --test-series master --locale en_US --test-apk-path app/build/outputs/apk/androidTest/debug/covid-notificatie-debug-androidTest.apk
           token: ${{secrets.APP_CENTER_TOKEN}}


### PR DESCRIPTION
Instrumentation tests didn't launch correctly due to an incorrect path to the test apk.