### PR TITLE
Implement transition with shared element

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/ExplanationFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/ExplanationFragment.kt
@@ -8,8 +8,10 @@ package nl.rijksoverheid.en.onboarding
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.transition.TransitionInflater
 import nl.rijksoverheid.en.BaseFragment
 import nl.rijksoverheid.en.R
 import nl.rijksoverheid.en.databinding.FragmentExplanationBinding
@@ -17,6 +19,17 @@ import nl.rijksoverheid.en.databinding.FragmentExplanationBinding
 class ExplanationFragment : BaseFragment(R.layout.fragment_explanation) {
 
     private val args: ExplanationFragmentArgs by navArgs()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.slide_right)
+        exitTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.slide_left)
+
+        val sharedTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+        sharedElementEnterTransition = sharedTransition
+        sharedElementReturnTransition = sharedTransition
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -26,7 +39,10 @@ class ExplanationFragment : BaseFragment(R.layout.fragment_explanation) {
         binding.description.setText(args.description)
         binding.illustration.setImageResource(args.illustration)
         binding.next.setOnClickListener {
-            findNavController().navigate(R.id.action_next)
+            val extras = FragmentNavigatorExtras(
+                binding.next to binding.next.transitionName
+            )
+            findNavController().navigate(R.id.action_next, null, null, extras)
         }
     }
 }

--- a/app/src/main/res/layout/fragment_explanation.xml
+++ b/app/src/main/res/layout/fragment_explanation.xml
@@ -53,6 +53,7 @@
         android:layout_marginEnd="@dimen/activity_horizontal_margin"
         android:layout_marginBottom="@dimen/activity_vertical_margin"
         android:text="@string/onboarding_next"
+        android:transitionName="next_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/navigation/nav_onboarding.xml
+++ b/app/src/main/res/navigation/nav_onboarding.xml
@@ -24,11 +24,7 @@
             app:argType="reference" />
         <action
             android:id="@+id/action_next"
-            app:destination="@id/explanationStep2"
-            app:enterAnim="@anim/slide_in_right"
-            app:exitAnim="@anim/slide_out_left"
-            app:popEnterAnim="@anim/slide_in_left"
-            app:popExitAnim="@anim/slide_out_right">
+            app:destination="@id/explanationStep2">
             <argument
                 android:name="title"
                 android:defaultValue="@string/onboarding_explanation_2_headline"
@@ -51,11 +47,7 @@
         tools:layout="@layout/fragment_explanation">
         <action
             android:id="@id/action_next"
-            app:destination="@id/explanationStep3"
-            app:enterAnim="@anim/slide_in_right"
-            app:exitAnim="@anim/slide_out_left"
-            app:popEnterAnim="@anim/slide_in_left"
-            app:popExitAnim="@anim/slide_out_right">
+            app:destination="@id/explanationStep3">
             <argument
                 android:name="title"
                 android:defaultValue="@string/onboarding_explanation_3_headline"


### PR DESCRIPTION
Implement a nicer transition between the explanation fragments where the button stays put.

![explanation-android](https://user-images.githubusercontent.com/2012474/83965937-c7e60700-a8a6-11ea-8820-e332901d1eaa.gif)
