### PR TITLE
Only allow HTTPS connections in production

### DIFF
--- a/api/src/main/java/nl/rijksoverheid/en/api/services.kt
+++ b/api/src/main/java/nl/rijksoverheid/en/api/services.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.Cache
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
@@ -25,6 +26,11 @@ internal fun createOkHttpClient(context: Context): OkHttpClient {
                 addInterceptor(HttpLoggingInterceptor().apply {
                     setLevel(HttpLoggingInterceptor.Level.BODY)
                 })
+            } else {
+                connectionSpecs(listOf(
+                    ConnectionSpec.MODERN_TLS,
+                    ConnectionSpec.COMPATIBLE_TLS
+                ))
             }
         }.build()
 }


### PR DESCRIPTION
Only allow HTTPS connections in production to prevent downgrade attacks.

Maybe also look at [certificate pinning](https://square.github.io/okhttp/https/#certificate-pinning-kt-java)?