### PR TITLE
CI: Run on all PRs

### DIFF
--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -1,6 +1,6 @@
 name: CI Covid19 Notification
 
-on: push
+on: [push, pull_request]
 
 jobs:
   run-test:


### PR DESCRIPTION
By default GitHub actions is disabled on forks, this PR ensures the CI runs on all pull requests.