### PR TITLE
CI: Add --warning-mode=fail to Gradle build

### DIFF
--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Check for code formatting violations
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck --warning-mode=fail
 
       - name: Build app
-        run: ./gradlew app:assemDevDebug testDevDebug testDebug app:lintDevDebug
+        run: ./gradlew app:assemDevDebug testDevDebug testDebug app:lintDevDebug --warning-mode=fail


### PR DESCRIPTION
Added `--warning-mode=fail` to the Gradle commands to let the CI fail if any warnings are thrown.

Can be merged when #53 is resolved.