### PR TITLE
Update Gradle to 6.8.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,5 @@
-#Mon Feb 15 09:23:07 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
-distributionSha256Sum=1433372d903ffba27496f8d5af24265310d2da0d78bf6b4e5138831d4fe066e9


### PR DESCRIPTION
Downloads the smaller bin zip, and also removes the `distributionSha256Sum`, since it throws a warning in Android Studio. The Gradle wrapper is validated in the CI each build [here](https://github.com/minvws/nl-covid19-notification-app-android/blob/master/.github/workflows/ci-app.yaml#L12).

```
WARNING: It is not fully supported to define distributionSha256Sum in gradle-wrapper.properties. Using an incorrect value may freeze or crash Android Studio.
```