### PR TITLE
Update GH actions to test and distribute

### DIFF
--- a/.github/actions/cleanup-credentials/action.yml
+++ b/.github/actions/cleanup-credentials/action.yml
@@ -1,0 +1,10 @@
+name: Clean up credentials
+description: "Clean up credentials"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Remove credentials"
+      run: |
+        rm -f keystore.jks firebase.json playstore.json
+      shell: bash

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,0 +1,18 @@
+name: common-setup
+description: "Setup build"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Set up JDK 11"
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: "Setup Gradle"
+      uses: gradle/gradle-build-action@v2
+
+    - name: "Set GRADLE_OPTS"
+      run: echo GRADLE_OPTS=-Xmx4g >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/credentials/action.yml
+++ b/.github/actions/credentials/action.yml
@@ -1,0 +1,36 @@
+name: credentials
+description: "Setup credentials"
+
+inputs:
+  keystoreFile:
+    description: "Base64 encoded key store"
+    required: false
+  firebaseServiceAccount:
+    description: "Firebase service account credentials"
+    required: false
+  playStoreServiceAccount:
+    description: "Play Store service account credentials"
+    required: false
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Keystore"
+      if: ${{ inputs.keyStoreFile }}
+      run: |
+        echo ${{ inputs.keyStoreFile }} | base64 --decode > keystore.jks
+        echo KEYSTORE_FILE=$GITHUB_WORKSPACE/keystore.jks >> $$GITHUB_ENV
+      shell: bash
+    - name: "Firebase credentials"
+      if: ${{ inputs.firebaseServiceAccount }}
+      run: |
+        echo '${{ inputs.firebaseServiceAccount }}' > firebase.json 
+        echo GOOGLE_APPLICATION_CREDENTIALS=$GITHUB_WORKSPACE/firebase.json >> $GITHUB_ENV
+      shell: bash
+    - name: "Play store credentials"
+      if: ${{ inputs.playStoreServiceAccount }}
+      run: |
+        echo '${{ inputs.playStoreServiceAccount }}' > playstore.json 
+        echo PLAY_STORE_CREDENTIALS=$GITHUB_WORKSPACE/playstore.json >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/credentials/action.yml
+++ b/.github/actions/credentials/action.yml
@@ -19,8 +19,8 @@ runs:
     - name: "Keystore"
       if: ${{ inputs.keyStoreFile }}
       run: |
-        echo ${{ inputs.keyStoreFile }} | base64 --decode > keystore.jks
-        echo KEYSTORE_FILE=$GITHUB_WORKSPACE/keystore.jks >> $$GITHUB_ENV
+        echo '${{ inputs.keyStoreFile }}' | base64 --decode > keystore.jks
+        echo KEYSTORE_FILE=$GITHUB_WORKSPACE/keystore.jks >> $GITHUB_ENV
       shell: bash
     - name: "Firebase credentials"
       if: ${{ inputs.firebaseServiceAccount }}

--- a/.github/actions/credentials/action.yml
+++ b/.github/actions/credentials/action.yml
@@ -28,7 +28,7 @@ runs:
         echo '${{ inputs.firebaseServiceAccount }}' > firebase.json 
         echo GOOGLE_APPLICATION_CREDENTIALS=$GITHUB_WORKSPACE/firebase.json >> $GITHUB_ENV
       shell: bash
-    - name: "Play store credentials"
+    - name: "Play Store credentials"
       if: ${{ inputs.playStoreServiceAccount }}
       run: |
         echo '${{ inputs.playStoreServiceAccount }}' > playstore.json 

--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -1,28 +1,89 @@
-name: CI Covid19 Notification
+name: 'Build & test'
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  run-test:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: "Checkout repository"
         uses: actions/checkout@v2
 
-      - name: Validate checksum gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+      - name: "Check out and setup Gradle"
+        uses: ./.github/actions/common-setup
 
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Check for code formatting violations
+      - name: "Check for code formatting violations"
         run: ./gradlew spotlessCheck --warning-mode=fail
 
-      - name: Build app
-        run: ./gradlew app:assemDevDebug testDevDebugUnitTest testDebugUnitTest app:lintDevDebug --warning-mode=fail
+      - name: "Build app"
+        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest --warning-mode=fail
 
+      - name: "Run tests"
+        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest testDevDebugUnitTestCoverage testDebugUnitTestCoverage app:lintDevDebug
+
+      - name: "Setup firebase credentials"
+        uses: ./.github/actions/credentials
+        with:
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: "Run instrumentation tests"
+        run: ./gradlew app:runFlank
+
+      - name: "Clean up credentials"
+        if: always()
+        uses: ./.github/actions/cleanup-credentials
+
+  distribute:
+    if: ${{ (github.ref == 'refs/heads/main') }}
+    env:
+      KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+      KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+    runs-on: ubuntu-latest
+    needs: [ "build" ]
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+
+      - name: "Check out and setup Gradle"
+        uses: ./.github/actions/common-setup
+
+      - name: "Setup credentials"
+        uses: ./.github/actions/credentials
+        with:
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          keystoreFile: ${{ secrets.KEYSTORE_FILE }}
+
+      - name: "Setup build id"
+        run: echo BUILD_ID=$(( $GITHUB_RUN_NUMBER + 170072 )) >> $GITHUB_ENV
+
+      - name: "Set release notes"
+        run: git log -1 --format=%B > app/src/main/play/release-notes/nl-NL/internal.txt
+
+      - name: "Distribute"
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+        run: ./gradlew app:bundleProdRelease app:assemAccRelease app:assemTstRelease app:assemProdRelease app:appDistributionUploadTstRelease app:appDistributionUploadAccRelease app:appDistributionUploadProdRelease
+
+      - name: "Publish APK"
+        uses: actions/upload-artifact@v3
+        with:
+          name: apk
+          path: app/build/outputs/apk/prod/release/*-release.apk
+
+      - name: "Publish bundle"
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundle
+          path: app/build/outputs/bundle/prodRelease/*-release.aab
+
+      - name: "Clean up credentials"
+        if: always()
+        uses: ./.github/actions/cleanup-credentials

--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -19,11 +19,8 @@ jobs:
       - name: "Check for code formatting violations"
         run: ./gradlew spotlessCheck --warning-mode=fail
 
-      - name: "Build app"
-        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest --warning-mode=fail
-
-      - name: "Run tests"
-        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest testDevDebugUnitTestCoverage testDebugUnitTestCoverage app:lintDevDebug
+      - name: "Build, test and lint app"
+        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest testDevDebugUnitTestCoverage testDebugUnitTest app:lintDevDebug --warning-mode=fail
 
       - name: "Setup firebase credentials"
         uses: ./.github/actions/credentials

--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v2
 
-      - name: "Check out and setup Gradle"
+      - name: "Setup Gradle"
         uses: ./.github/actions/common-setup
 
       - name: "Check for code formatting violations"
@@ -47,7 +47,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v2
 
-      - name: "Check out and setup Gradle"
+      - name: "Setup Gradle"
         uses: ./.github/actions/common-setup
 
       - name: "Setup credentials"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ apply from: rootProject.file("jacoco.gradle")
 
 version = "2.5.10"
 def buildVersionCode = System.getenv("BUILD_ID") != null ? System.getenv("BUILD_ID").toInteger() : 125210
+archivesBaseName = "coronamelder-${version}-${buildVersionCode}"
 
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()


### PR DESCRIPTION
Update ci to:

* Build and test the app, running instrumentation tests on Firebase Test Lab
* When build and test step is successful, and only for the `main` branch (after PR merge) distribute prod, acc and test builds using Firebase app distribution. Also attaches the production versions as artifacts for later deployment to the Play Store.

Workflow for releasing a to the Play Store will be a separate PR as it requires this one to be merged first :)

Ref minvws/nl-covid19-notification-app-coordination-private#8