### PR TITLE
Dependency and projects updates

### DIFF
--- a/.github/workflows/ci-app.yaml
+++ b/.github/workflows/ci-app.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: ./.github/actions/common-setup
 
       - name: "Check for code formatting violations"
-        run: ./gradlew spotlessCheck --warning-mode=fail
+        run: ./gradlew spotlessCheck
 
       - name: "Build, test and lint app"
-        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest testDevDebugUnitTestCoverage testDebugUnitTest app:lintDevDebug --warning-mode=fail
+        run: ./gradlew app:assemDevDebug app:assemDevDebugAndroidTest testDevDebugUnitTestCoverage testDebugUnitTest app:lintDevDebug
 
       - name: "Setup firebase credentials"
         uses: ./.github/actions/credentials

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,9 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
+    id 'jacoco'
+}
 apply from: rootProject.file("jacoco.gradle")
 
 ext.cdnEndpoint = ext.has("cdnEndpoint") ? ext.cdnEndpoint : "http://localhost/"
@@ -76,43 +79,23 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-
-    // ResponseSignatureValidator
     implementation project(":signing")
-
-    // Java 8+ API desugaring support
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-
-    // Coroutines
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-
-    // Retrofit
-    api "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
-
-    // OkHttp
-    api "com.squareup.okhttp3:okhttp:$okhttp3_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3_version"
-
-    // Moshi Json parsing
-    implementation("com.squareup.moshi:moshi-kotlin:$moshi_version") {
+    coreLibraryDesugaring libs.desugar
+    api libs.kotlin.coroutines.android
+    api libs.retrofit2
+    implementation libs.retrofit2.converter.moshi
+    api libs.okhttp3
+    implementation libs.okhttp3.logging.interceptor
+    implementation(libs.moshi.kotlin) {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-reflect"
     }
-    implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
+    implementation libs.moshi.adapters
+    kapt libs.moshi.kotlin.codegen
+    implementation libs.timber
 
-    // Timber logger
-    implementation "com.jakewharton.timber:timber:$timber_version"
-
-    // JUnit
-    testImplementation "junit:junit:$junit_version"
-    testImplementation "androidx.test:core:$androidx_test_core_version"
-
-    // OkHttp mock webserver
-    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3_version"
-    // OkHttp-TLS: Used by TLS related unit tests
-    testImplementation "com.squareup.okhttp3:okhttp-tls:$okhttp3_version"
-    // Roboelectr test runner
-    testImplementation "org.robolectric:robolectric:$robolectric_version"
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.okhttp3.mockwebserver
+    testImplementation libs.okhttp3.tls
+    testImplementation libs.robolectric
 }

--- a/api/src/main/java/nl/rijksoverheid/en/api/model/AppConfig.kt
+++ b/api/src/main/java/nl/rijksoverheid/en/api/model/AppConfig.kt
@@ -33,7 +33,8 @@ data class AppConfig(
     @Json(name = "coronaTestURL") val coronaTestURL: String = DEFAULT_APPOINTMENT_URL,
     @Json(name = "featureFlags") val featureFlags: List<FeatureFlag> = listOf(
         FeatureFlag(
-            FeatureFlagOption.INDEPENDENT_KEY_SHARING.id, true
+            FeatureFlagOption.INDEPENDENT_KEY_SHARING.id,
+            true
         )
     ),
     @Json(name = "notification") val notification: AppMessage? = null

--- a/api/src/main/java/nl/rijksoverheid/en/api/services.kt
+++ b/api/src/main/java/nl/rijksoverheid/en/api/services.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.api
 
 import android.content.Context

--- a/api/src/test/java/nl/rijksoverheid/en/api/CorruptedCacheInterceptorTest.kt
+++ b/api/src/test/java/nl/rijksoverheid/en/api/CorruptedCacheInterceptorTest.kt
@@ -56,8 +56,8 @@ class CorruptedCacheInterceptorTest {
         cache = Cache(tmpDir, 1024 * 1024L)
     }
 
-    @Test(expected = NullPointerException::class)
     // if this test starts failing, the OkHttp bug might have been fixed
+    @Test(expected = NullPointerException::class)
     fun `OkHttp crashes when certificates in cache entry are corrupted`() {
         mockWebServer.enqueue(
             MockResponse().setResponseCode(200)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: "kotlin-kapt"
-apply plugin: "androidx.navigation.safeargs.kotlin"
-apply plugin: "com.github.triplet.play"
-apply plugin: "com.osacky.fladle"
-apply plugin: 'com.google.firebase.appdistribution'
-apply plugin: 'ru.cian.huawei-publish'
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.navigation.safeargs)
+    alias(libs.plugins.tripletPlay)
+    alias(libs.plugins.fladle)
+    alias(libs.plugins.firebase.appdistribution)
+    id 'jacoco'
+}
+
 apply from: rootProject.file("jacoco.gradle")
 
 version = "2.5.10"
@@ -156,15 +159,6 @@ play {
     track = "internal"
 }
 
-huaweiPublish {
-    instances {
-        prodRelease {
-            buildFormat = "aab"
-            publish = false
-        }
-    }
-}
-
 fladle {
     projectId = "vws-coronamelder"
     variant = "devDebug"
@@ -175,136 +169,56 @@ fladle {
     testTargets = ["notAnnotation nl.rijksoverheid.en.screenshots.StoreScreenshots"]
 }
 
-repositories {
-    maven {
-        url "https://jitpack.io"
-        content {
-            includeGroup "com.github.pandulapeter.beagle"
-            includeGroup "com.github.blipinsk"
-            includeGroup "com.github.lisawray.groupie"
-        }
-    }
-}
-
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-
-    // Java 8+ API desugaring support
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-
-    // Service Api
+    coreLibraryDesugaring libs.desugar
     implementation project(":api")
-    // ExposureNotificationApi
     implementation project(":en-api")
-    // ResponseSignatureValidator
     implementation project(":signing")
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.activity
+    implementation libs.androidx.fragment
+    implementation libs.androidx.core
+    implementation libs.androidx.core.splashscreen
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.browser
+    implementation libs.androidx.lifecycle.viewmodel
+    implementation libs.androidx.lifecycle.livedata
+    implementation libs.androidx.lifecycle.common.java8
+    implementation libs.androidx.lifecycle.process
+    implementation libs.androidx.work.runtime
+    implementation libs.androidx.preference
+    implementation libs.androidx.security.crypto
+    implementation libs.androidx.navigation.fragment
+    implementation libs.androidx.navigation.ui
+    androidTestImplementation libs.androidx.navigation.testing
+    implementation libs.timber
+    implementation libs.material
+    implementation libs.bundles.play.core
+    implementation libs.bundles.playServices
+    implementation libs.lottie
+    implementation libs.bundles.groupie
+    implementation libs.insetter
 
-    // AndroidX
-    implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
-    implementation "androidx.activity:activity-ktx:$androidx_activity_version"
-    implementation "androidx.fragment:fragment-ktx:$androidx_fragment_version"
-    implementation "androidx.core:core-ktx:$androidx_core_version"
-
-    // Splashscreen
-    implementation 'androidx.core:core-splashscreen:1.0.0-beta02'
-
-    // ConstraintLayout
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-
-    // CustomTabs
-    implementation "androidx.browser:browser:1.4.0"
-
-    // Lifecycle components
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidx_lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidx_lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-common-java8:$androidx_lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-process:$androidx_lifecycle_version"
-
-    // WorkManager (UI independent background tasks)
-    implementation "androidx.work:work-runtime-ktx:$androidx_work_version"
-
-    // SharedPreferences
-    implementation "androidx.preference:preference-ktx:1.2.0"
-    // EncryptedSharedPreferences
-    implementation "androidx.security:security-crypto:1.1.0-alpha03"
-
-    // Navigation components
-    implementation "androidx.navigation:navigation-fragment-ktx:$androidx_nav_version"
-    implementation "androidx.navigation:navigation-ui-ktx:$androidx_nav_version"
-    androidTestImplementation "androidx.navigation:navigation-testing:$androidx_nav_version"
-
-
-    // Timber logger
-    implementation "com.jakewharton.timber:timber:$timber_version"
-
-    // Material components
-    implementation 'com.google.android.material:material:1.5.0'
-
-    // Google Play Core Library
-    implementation "com.google.android.play:core:1.10.3"
-    implementation "com.google.android.play:core-ktx:1.8.1"
-
-    // Google play services
-    implementation "com.google.android.gms:play-services-base:$play_services_base_version"
-    implementation "com.google.android.gms:play-services-basement:$play_services_base_version"
-    implementation "com.google.android.gms:play-services-tasks:$play_services_tasks_version"
-
-    // Lottie animations
-    implementation 'com.airbnb.android:lottie:4.2.2'
-
-    // Groupie (RecyclerView builder)
-    implementation "com.github.lisawray.groupie:groupie:$groupie_version"
-    implementation "com.github.lisawray.groupie:groupie-viewbinding:$groupie_version"
-
-    // Insetter (WindowInsets util)
-    implementation "dev.chrisbanes.insetter:insetter:$insetter_version"
-
-    // UnitTest support classes
     testImplementation project(":test-support")
     debugImplementation project(":test-support")
     androidTestDebugImplementation project(":test-support")
-
-    // Unit testing
-    testImplementation "junit:junit:$junit_version"
-    testImplementation "androidx.arch.core:core-testing:$arch_core_version"
-    testImplementation "androidx.work:work-testing:$androidx_work_version"
-
-    // Mockito
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitokotlin_version"
-    testImplementation "org.mockito:mockito-core:$mockito_version"
-    androidTestImplementation "org.mockito:mockito-android:$mockito_version"
-    androidTestImplementation "org.mockito.kotlin:mockito-kotlin:$mockitokotlin_version"
-
-    // MockWebServer
-    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3_version"
-
-    // Coroutine testing util
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
-
-    // Roboelectric test runner
-    testImplementation "org.robolectric:robolectric:$robolectric_version"
-
-    // AndroidTests
-    androidTestImplementation "androidx.arch.core:core-testing:$arch_core_version"
-    androidTestImplementation "androidx.test.ext:junit:$androidx_test_ext_junit_version"
-
-    // Espresso (Android UI tests)
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$androidx_espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:$androidx_espresso_version"
-
-    // UI Automator
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-
-    // JUnit TestRule for Android instrumented tests, which automatically disables and enables animations
-    androidTestImplementation 'com.github.blipinsk:disable-animations-rule:2.0.0'
-    // JUnit rule for specifying some of the UI demo commands and customize some part of the Status as well as the Navigation bar
-    androidTestImplementation 'com.vanniktech:junit4-android-integration-rules:0.3.0'
-
-    // Fastlane Screengrab: localized screenshots
-    androidTestImplementation 'tools.fastlane:screengrab:2.1.1'
-
-    // Beagle debug drawer
-    def beagleVersion = "2.5.1"
-    tstImplementation "com.github.pandulapeter.beagle:ui-drawer:$beagleVersion"
+    testImplementation libs.junit
+    testImplementation libs.androidx.core.testing
+    testImplementation libs.androidx.work.testing
+    testImplementation libs.mockito.kotlin
+    testImplementation libs.mockito.core
+    androidTestImplementation libs.mockito.android
+    androidTestImplementation libs.mockito.kotlin
+    testImplementation libs.okhttp3.mockwebserver
+    testImplementation libs.kotlin.coroutines.testing
+    testImplementation libs.robolectric
+    androidTestImplementation libs.androidx.core.testing
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.bundles.espresso
+    androidTestImplementation libs.androidx.test.uiautomator
+    // TODO check if this is needed; the test runner should already do this
+    androidTestImplementation libs.disableAnimationsRule
+    androidTestImplementation libs.junit4AndroidIntegrationRules
+    androidTestImplementation libs.fastlane.screengrab
+    tstImplementation libs.beagle.ui.drawer
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,7 +149,7 @@ android {
     }
 
     kotlinOptions {
-        freeCompilerArgs += ["-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
+        freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 apply from: rootProject.file("jacoco.gradle")
 
-version = "2.5.10"
+version = "2.5.11"
 def buildVersionCode = System.getenv("BUILD_ID") != null ? System.getenv("BUILD_ID").toInteger() : 125210
 archivesBaseName = "coronamelder-${version}-${buildVersionCode}"
 

--- a/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/EnableApiFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/EnableApiFragmentTest.kt
@@ -122,7 +122,8 @@ class EnableApiFragmentTest : BaseInstrumentationTest() {
     )
 
     private val settingsRepository = SettingsRepository(
-        context, nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
+        context,
+        nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
     )
     private val onboardingRepository = OnboardingRepository(onboardingPreferences) {
         true
@@ -157,7 +158,8 @@ class EnableApiFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Explanation button navigates to how it works screen",
-                R.id.nav_how_it_works, navController.currentDestination?.id
+                R.id.nav_how_it_works,
+                navController.currentDestination?.id
             )
         }
     }
@@ -201,7 +203,8 @@ class EnableApiFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Skip button opens skip dialog",
-                R.id.nav_skip_consent_confirmation, navController.currentDestination?.id
+                R.id.nav_skip_consent_confirmation,
+                navController.currentDestination?.id
             )
         }
     }

--- a/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/ExplanationFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/ExplanationFragmentTest.kt
@@ -44,7 +44,8 @@ class ExplanationFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in first step of explanation navigates to second step",
-                R.id.explanationStep2, navController.currentDestination?.id
+                R.id.explanationStep2,
+                navController.currentDestination?.id
             )
         }
     }
@@ -66,7 +67,8 @@ class ExplanationFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in second step of explanation navigates to third step",
-                R.id.explanationStep3, navController.currentDestination?.id
+                R.id.explanationStep3,
+                navController.currentDestination?.id
             )
         }
     }
@@ -88,7 +90,8 @@ class ExplanationFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in third step of explanation navigates to first example screen",
-                R.id.explanationExample1, navController.currentDestination?.id
+                R.id.explanationExample1,
+                navController.currentDestination?.id
             )
         }
     }
@@ -110,7 +113,8 @@ class ExplanationFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in first example screen navigates to second example screen",
-                R.id.explanationExample2, navController.currentDestination?.id
+                R.id.explanationExample2,
+                navController.currentDestination?.id
             )
         }
     }
@@ -132,7 +136,8 @@ class ExplanationFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in second example screen navigates to consent screen",
-                R.id.nav_privacy_policy_consent, navController.currentDestination?.id
+                R.id.nav_privacy_policy_consent,
+                navController.currentDestination?.id
             )
         }
     }

--- a/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/HowItWorksDetailFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/HowItWorksDetailFragmentTest.kt
@@ -105,7 +105,8 @@ class HowItWorksDetailFragmentTest : BaseInstrumentationTest() {
     )
 
     private val settingsRepository = SettingsRepository(
-        context, nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
+        context,
+        nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
     )
 
     private val onboardingRepository = OnboardingRepository(onboardingPreferences) {

--- a/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/HowItWorksFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/HowItWorksFragmentTest.kt
@@ -118,7 +118,8 @@ class HowItWorksFragmentTest : BaseInstrumentationTest() {
         AppConfigManager(service, { false }, { emptyList() })
     )
     private val settingsRepository = SettingsRepository(
-        context, nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
+        context,
+        nl.rijksoverheid.en.settings.Settings(context, settingsPreferences)
     )
     private val onboardingRepository = OnboardingRepository(onboardingPreferences) {
         true
@@ -153,7 +154,8 @@ class HowItWorksFragmentTest : BaseInstrumentationTest() {
 
             Assert.assertEquals(
                 "Pressing FAQ item navigates to detail page",
-                R.id.nav_how_it_works_detail, navController.currentDestination?.id
+                R.id.nav_how_it_works_detail,
+                navController.currentDestination?.id
             )
         }
     }

--- a/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/PrivacyPolicyConsentFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/onboarding/PrivacyPolicyConsentFragmentTest.kt
@@ -143,7 +143,8 @@ class PrivacyPolicyConsentFragmentTest : BaseInstrumentationTest() {
 
             assertEquals(
                 "Pressing next button in privacy policy consent screen navigates to enable api screen",
-                R.id.nav_enable_api, navController.currentDestination?.id
+                R.id.nav_enable_api,
+                navController.currentDestination?.id
             )
         }
     }

--- a/app/src/androidTest/java/nl/rijksoverheid/en/screenshots/StoreScreenshotsTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/screenshots/StoreScreenshotsTest.kt
@@ -156,7 +156,8 @@ class StoreScreenshotsTest : BaseInstrumentationTest() {
         clock = clock
     )
     private val settingsRepository = SettingsRepository(
-        context, Settings(context, settingsPreferences)
+        context,
+        Settings(context, settingsPreferences)
     )
 
     private val statusViewModel = StatusViewModel(

--- a/app/src/androidTest/java/nl/rijksoverheid/en/status/StatusFragmentTest.kt
+++ b/app/src/androidTest/java/nl/rijksoverheid/en/status/StatusFragmentTest.kt
@@ -135,7 +135,8 @@ class StatusFragmentTest : BaseInstrumentationTest() {
     }
     private val settingsRepository by lazy {
         SettingsRepository(
-            context, Settings(context, settingsPreferences)
+            context,
+            Settings(context, settingsPreferences)
         )
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/ExposureNotificationsRepository.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/ExposureNotificationsRepository.kt
@@ -286,8 +286,8 @@ class ExposureNotificationsRepository(
     fun isLocationPreconditionSatisfied(): Boolean {
         return exposureNotificationsApi.deviceSupportsLocationlessScanning() ||
             context.getSystemService(LocationManager::class.java)?.let {
-            LocationManagerCompat.isLocationEnabled(it)
-        } ?: true
+                LocationManagerCompat.isLocationEnabled(it)
+            } ?: true
     }
 
     /**
@@ -405,20 +405,23 @@ class ExposureNotificationsRepository(
                 riskCalculationParameters.attenuationBucketWeights
             ).apply {
                 riskCalculationParameters.infectiousnessWeights.forEachIndexed { infectiousness, weight ->
-                    if (isValidInfectiousnessWeight(infectiousness, weight))
+                    if (isValidInfectiousnessWeight(infectiousness, weight)) {
                         setInfectiousnessWeight(infectiousness, weight)
+                    }
                 }
                 riskCalculationParameters.reportTypeWeights.forEachIndexed { reportType, weight ->
-                    if (isValidReportTypeWeight(reportType, weight))
+                    if (isValidReportTypeWeight(reportType, weight)) {
                         setReportTypeWeight(reportType, weight)
+                    }
                 }
             }.build()
     }
 
     private fun isValidInfectiousnessWeight(infectiousness: Int, weight: Double): Boolean {
         val invalidWeight = weight < 0.0 || weight > 2.5
-        if (invalidWeight)
+        if (invalidWeight) {
             Timber.w("Element value of infectiousnessWeights must between 0 ~ 2.5")
+        }
 
         // Infectiousness.NONE will trigger a (IllegalArgumentException: Incorrect value of infectiousness)
         return infectiousness != Infectiousness.NONE && !invalidWeight
@@ -426,8 +429,9 @@ class ExposureNotificationsRepository(
 
     private fun isValidReportTypeWeight(reportType: Int, weight: Double): Boolean {
         val invalidWeight = weight < 0.0 || weight > 2.5
-        if (invalidWeight)
+        if (invalidWeight) {
             Timber.w("Element value of reportTypeWeights must between 0 ~ 2.5")
+        }
 
         // ReportType.UNKNOWN and ReportType.REVOKED will trigger a (IllegalArgumentException: Incorrect value of ReportType)
         return reportType != ReportType.UNKNOWN && reportType != ReportType.REVOKED && !invalidWeight
@@ -698,8 +702,9 @@ class ExposureNotificationsRepository(
 
         val dailyRiskScoresResult =
             exposureNotificationsApi.getDailyRiskScores(dailySummariesConfig)
-        if (dailyRiskScoresResult is DailyRiskScoresResult.UnknownError)
+        if (dailyRiskScoresResult is DailyRiskScoresResult.UnknownError) {
             return AddExposureResult.Error
+        }
 
         val riskScores =
             (dailyRiskScoresResult as? DailyRiskScoresResult.Success)?.dailyRiskScores?.filter {
@@ -728,7 +733,8 @@ class ExposureNotificationsRepository(
                 putLong(KEY_LAST_TOKEN_EXPOSURE_DATE, newExposureEpochDay)
                 putLong(KEY_PREVIOUSLY_KNOWN_EXPOSURE_DATE, newExposureEpochDay)
                 putLong(
-                    KEY_LAST_NOTIFICATION_RECEIVED_DATE, newNotificationReceivedDate.toEpochDay()
+                    KEY_LAST_NOTIFICATION_RECEIVED_DATE,
+                    newNotificationReceivedDate.toEpochDay()
                 )
             }
             AddExposureResult.Notify(

--- a/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
@@ -96,8 +96,9 @@ class MainActivity : AppCompatActivity() {
                 is AppLifecycleViewModel.AppLifecycleStatus.UnableToFetchAppConfig ->
                     handleUnableToFetchAppConfig()
                 else -> {
-                    if (!navController.isInitialised())
+                    if (!navController.isInitialised()) {
                         inflateNavGraph()
+                    }
                 }
             }
         }
@@ -109,12 +110,14 @@ class MainActivity : AppCompatActivity() {
 
     private fun handleUpdateState(update: AppLifecycleManager.UpdateState) {
         if (update is AppLifecycleManager.UpdateState.InAppUpdate) {
-            if (!navController.isInitialised())
+            if (!navController.isInitialised()) {
                 inflateNavGraph()
+            }
 
             update.appUpdateManager.startUpdateFlow(
                 update.appUpdateInfo,
-                this, AppUpdateOptions.defaultOptions(AppUpdateType.IMMEDIATE)
+                this,
+                AppUpdateOptions.defaultOptions(AppUpdateType.IMMEDIATE)
             ).addOnCompleteListener { task ->
                 Timber.d("App update result: ${task.result}")
                 if (task.result != Activity.RESULT_OK) {
@@ -122,9 +125,9 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         } else {
-            if (!navController.isInitialised())
+            if (!navController.isInitialised()) {
                 inflateNavGraph(R.id.nav_app_update_required)
-            else {
+            } else {
                 val installerPackageName =
                     (update as AppLifecycleManager.UpdateState.UpdateRequired).installerPackageName
                 navController.navigate(
@@ -144,19 +147,21 @@ class MainActivity : AppCompatActivity() {
 
     private fun handleEndOfLifeState() {
         viewModel.disableExposureNotifications()
-        if (!navController.isInitialised())
+        if (!navController.isInitialised()) {
             inflateNavGraph(R.id.nav_end_of_life)
-        else
+        } else {
             navController.navigate(EndOfLifeFragmentDirections.actionEndOfLife())
+        }
     }
 
     private fun handleUnableToFetchAppConfig() {
-        if (!navController.isInitialised())
+        if (!navController.isInitialised()) {
             inflateNavGraph(R.id.nav_no_internet)
-        else
+        } else {
             navController.navigate(
                 NoInternetFragmentDirections.actionNoInternet()
             )
+        }
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/nl/rijksoverheid/en/about/FAQItemDecoration.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/about/FAQItemDecoration.kt
@@ -50,7 +50,9 @@ class FAQItemDecoration(context: Context, @Dimension val startOffset: Int) :
             left = parent.paddingLeft
             right = parent.width - parent.paddingRight
             canvas.clipRect(
-                left, parent.paddingTop, right,
+                left,
+                parent.paddingTop,
+                right,
                 parent.height - parent.paddingBottom
             )
         } else {

--- a/app/src/main/java/nl/rijksoverheid/en/about/IllustratedBoxItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/about/IllustratedBoxItem.kt
@@ -31,7 +31,10 @@ open class IllustratedBoxItem(
     override fun getLayout() = R.layout.item_illustrated_box
     override fun bind(viewBinding: ItemIllustratedBoxBinding, position: Int) {
         viewBinding.viewState = ViewState(
-            title, subtitle, illustration, viewBinding.root.context.getColor(backgroundTint)
+            title,
+            subtitle,
+            illustration,
+            viewBinding.root.context.getColor(backgroundTint)
         )
         viewBinding.constraintLayout.clipToOutline = true
     }

--- a/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppLifecycleViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppLifecycleViewModel.kt
@@ -46,8 +46,9 @@ class AppLifecycleViewModel(
      * Check in app config for required [AppLifecycleStatus].
      */
     fun checkAppLifecycleStatus() {
-        if (checkForForcedAppUpdateJob?.isActive == true)
+        if (checkForForcedAppUpdateJob?.isActive == true) {
             return
+        }
 
         checkForForcedAppUpdateJob = viewModelScope.launch {
             try {

--- a/app/src/main/java/nl/rijksoverheid/en/applifecycle/NoInternetFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/applifecycle/NoInternetFragment.kt
@@ -27,8 +27,9 @@ class NoInternetFragment : Fragment(R.layout.fragment_no_internet) {
         }
 
         appLifecycleViewModel.appLifecycleStatus.observe(viewLifecycleOwner) {
-            if (it is AppLifecycleViewModel.AppLifecycleStatus.Ready)
+            if (it is AppLifecycleViewModel.AppLifecycleStatus.Ready) {
                 findNavController().popBackStack()
+            }
         }
     }
 }

--- a/app/src/main/java/nl/rijksoverheid/en/appmessage/AppMessageReceiver.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/appmessage/AppMessageReceiver.kt
@@ -63,8 +63,9 @@ class AppMessageReceiver : BroadcastReceiver() {
 
             val shouldScheduleBasedOnProbability = notification.shouldScheduleBasedOnProbability()
             Timber.d("Schedule notification based on probability result: $shouldScheduleBasedOnProbability")
-            if (!shouldScheduleBasedOnProbability)
+            if (!shouldScheduleBasedOnProbability) {
                 return
+            }
 
             Timber.d("Schedule")
             val pendingIntent = createPendingIntent(context)

--- a/app/src/main/java/nl/rijksoverheid/en/config/AppConfigManager.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/config/AppConfigManager.kt
@@ -43,10 +43,11 @@ class AppConfigManager(
      */
     suspend fun getConfig(): AppConfig {
         return cdnService.getAppConfig(cdnService.getManifest().appConfigId).let { appConfig ->
-            if (useDebugFeatureFlags())
+            if (useDebugFeatureFlags()) {
                 appConfig.copy(featureFlags = getDebugFeatureFlags())
-            else
+            } else {
                 appConfig
+            }
         }
     }
 
@@ -56,10 +57,11 @@ class AppConfigManager(
      */
     suspend fun getConfigOrDefault(): AppConfig = getConfigOrDefault {
         cdnService.getAppConfig(cdnService.getManifest().appConfigId).let { appConfig ->
-            if (useDebugFeatureFlags())
+            if (useDebugFeatureFlags()) {
                 appConfig.copy(featureFlags = getDebugFeatureFlags())
-            else
+            } else {
                 appConfig
+            }
         }
     }
 
@@ -72,10 +74,11 @@ class AppConfigManager(
             cdnService.getManifest(CacheStrategy.CACHE_FIRST).appConfigId,
             CacheStrategy.CACHE_FIRST
         ).let { appConfig ->
-            if (useDebugFeatureFlags())
+            if (useDebugFeatureFlags()) {
                 appConfig.copy(featureFlags = getDebugFeatureFlags())
-            else
+            } else {
                 appConfig
+            }
         }
     }
 }

--- a/app/src/main/java/nl/rijksoverheid/en/databinding/BindingAdapters.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/databinding/BindingAdapters.kt
@@ -179,7 +179,8 @@ object BindingAdapters {
     @BindingAdapter("pausedState")
     fun bindPausedState(view: HtmlTextViewWidget, pausedUntil: LocalDateTime?) {
         val formattedDuration = pausedUntil?.formatPauseDuration(view.context)
-        if (view.text != formattedDuration)
+        if (view.text != formattedDuration) {
             view.setHtmlText(formattedDuration)
+        }
     }
 }

--- a/app/src/main/java/nl/rijksoverheid/en/items/ParagraphItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/items/ParagraphItem.kt
@@ -20,10 +20,11 @@ class ParagraphItem(
 
     override fun bind(viewBinding: ItemParagraphBinding, position: Int) {
         viewBinding.content.setHtmlText(viewBinding.root.context.getString(text, *formatArgs))
-        if (clickable)
+        if (clickable) {
             viewBinding.content.enableCustomLinks {
                 viewBinding.root.callOnClick()
             }
+        }
     }
 
     override fun isClickable() = clickable

--- a/app/src/main/java/nl/rijksoverheid/en/job/ExposureCleanupWorker.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/job/ExposureCleanupWorker.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 class ExposureCleanupWorker(
     context: Context,
     params: WorkerParameters,
-    private val repository: ExposureNotificationsRepository,
+    private val repository: ExposureNotificationsRepository
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {

--- a/app/src/main/java/nl/rijksoverheid/en/job/ExposureNotificationJob.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/job/ExposureNotificationJob.kt
@@ -44,10 +44,11 @@ class ExposureNotificationJob(
             }
             is AddExposureResult.Processed -> Result.success()
             is AddExposureResult.Error -> {
-                if (runAttemptCount + 1 < MAX_RUN_ATTEMPTS)
+                if (runAttemptCount + 1 < MAX_RUN_ATTEMPTS) {
                     Result.retry()
-                else
+                } else {
                     Result.failure()
+                }
             }
         }
     }

--- a/app/src/main/java/nl/rijksoverheid/en/job/RemindExposureNotificationWorker.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/job/RemindExposureNotificationWorker.kt
@@ -44,7 +44,8 @@ class RemindExposureNotificationWorker(
     companion object {
         fun schedule(context: Context) {
             val request = PeriodicWorkRequestBuilder<RemindExposureNotificationWorker>(
-                REMINDER_INTERVAL_HOURS, TimeUnit.HOURS
+                REMINDER_INTERVAL_HOURS,
+                TimeUnit.HOURS
             )
                 .setInitialDelay(REMINDER_INTERVAL_HOURS, TimeUnit.HOURS)
                 .build()

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestDoneSection.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestDoneSection.kt
@@ -21,7 +21,7 @@ class LabTestDoneSection(
     close: () -> Unit
 ) : Section(
 
-    if (hasIndependentKeySharing)
+    if (hasIndependentKeySharing) {
         listOf(
             IllustrationItem(R.drawable.illustration_lab_test_done),
             HeaderItem(R.string.lab_test_done_generic_header_1),
@@ -30,7 +30,7 @@ class LabTestDoneSection(
             MessageBoxItem(R.string.lab_test_done_generic_box_4),
             ButtonItem(R.string.lab_test_done_button, close)
         )
-    else
+    } else {
         listOf(
             IllustrationItem(R.drawable.illustration_lab_test_done),
             HeaderItem(R.string.lab_test_done_header_1),
@@ -39,4 +39,5 @@ class LabTestDoneSection(
             MessageBoxItem(R.string.lab_test_done_box_4),
             ButtonItem(R.string.lab_test_done_button, close)
         )
+    }
 )

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestFragment.kt
@@ -124,7 +124,6 @@ class LabTestFragment : BaseFragment(R.layout.fragment_list_with_button) {
         keyState: LabTestViewModel.KeyState,
         notificationsState: ExposureNotificationsViewModel.NotificationsState
     ): Boolean {
-
         return keyState is LabTestViewModel.KeyState.Success &&
             notificationsState in listOf(
             ExposureNotificationsViewModel.NotificationsState.Enabled,

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestRepository.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestRepository.kt
@@ -253,7 +253,8 @@ class LabTestRepository(
             listOf(
                 nl.rijksoverheid.en.api.model.TemporaryExposureKey(
                     key,
-                    (clock.millis() / 600000L).toInt(), 144
+                    (clock.millis() / 600000L).toInt(),
+                    144
                 )
             ),
             generateDecoyBucketId(bucketId.length)

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestSection.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestSection.kt
@@ -45,7 +45,7 @@ class LabTestSection(
                 LabTestStepItem(R.string.lab_test_step_1, 1, isFirstElement = true),
                 LabTestKeyItem(keyState, copy, retry),
                 LabTestStepItem(R.string.lab_test_step_2, 2),
-                LabTestStepItem(R.string.lab_test_step_3, 3, isLastElement = true),
+                LabTestStepItem(R.string.lab_test_step_3, 3, isLastElement = true)
             ).apply {
                 if (notificationsState is NotificationsState.Disabled || notificationsState is NotificationsState.Unavailable) {
                     add(

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/LabTestViewModel.kt
@@ -67,8 +67,9 @@ class LabTestViewModel(
 
     fun checkKeyExpiration() {
         viewModelScope.launch {
-            if (labTestRepository.isKeyDataExpired())
+            if (labTestRepository.isKeyDataExpired()) {
                 (keyExpiredEvent as MutableLiveData).value = Event(Unit)
+            }
         }
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/coronatest/CoronaTestKeySharingFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/coronatest/CoronaTestKeySharingFragment.kt
@@ -66,8 +66,9 @@ class CoronaTestKeySharingFragment : BaseFragment(R.layout.fragment_list) {
 
         setSlideTransition()
 
-        if (labViewModel.usedKey == null)
+        if (labViewModel.usedKey == null) {
             labViewModel.retry()
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -94,8 +95,9 @@ class CoronaTestKeySharingFragment : BaseFragment(R.layout.fragment_list) {
         }
         labViewModel.uploadResult.observe(viewLifecycleOwner) { uploadResultEvent ->
             // Update UI also when event was already handled
-            if (uploadResultEvent.peekContent() is LabTestViewModel.UploadResult.Success)
+            if (uploadResultEvent.peekContent() is LabTestViewModel.UploadResult.Success) {
                 section.uploadKeysSucceeded()
+            }
 
             // Handle others results only once
             when (val it = uploadResultEvent.getContentIfNotHandled()) {

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/coronatest/FinishKeySharingDialogFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/coronatest/FinishKeySharingDialogFragment.kt
@@ -25,7 +25,8 @@ class FinishKeySharingDialogFragment : DialogFragment() {
             .setMessage(getString(R.string.coronatest_finish_confirmation_text))
             .setPositiveButton(R.string.coronatest_finish_confirmation_accept) { _, _ ->
                 findNavController().currentBackStackEntry?.savedStateHandle?.set(
-                    FINISH_KEY_SHARING_RESULT, true
+                    FINISH_KEY_SHARING_RESULT,
+                    true
                 )
             }
             .setNegativeButton(R.string.coronatest_finish_confirmation_cancel, null)

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/items/LabTestKeyItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/items/LabTestKeyItem.kt
@@ -42,12 +42,13 @@ class LabTestKeyItem(
             displayKey = (keyState as? KeyState.Success)?.displayKey,
             enabled = enabled,
             retry = retry,
-            keyContentDescription = if (enabled)
+            keyContentDescription = if (enabled) {
                 key?.lowercase(Locale.ROOT)
                     ?.replace(Regex("(.)"), "$1 ")
                     ?.trimEnd()
-            else
+            } else {
                 viewBinding.root.context.getString(R.string.lab_test_key_cd)
+            }
         )
 
         viewBinding.viewState = viewState

--- a/app/src/main/java/nl/rijksoverheid/en/labtest/items/LabTestShareKeysItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/labtest/items/LabTestShareKeysItem.kt
@@ -31,10 +31,11 @@ class LabTestShareKeysItem(
     )
 
     private val viewState = ViewState(
-        uploadButtonText = if (hasSharedKeys)
+        uploadButtonText = if (hasSharedKeys) {
             R.string.coronatest_keys_shared
-        else
-            R.string.coronatest_share_keys,
+        } else {
+            R.string.coronatest_share_keys
+        },
         showButton = keyState is KeyState.Success,
         showProgress = keyState == KeyState.Loading,
         showError = keyState is KeyState.Error,

--- a/app/src/main/java/nl/rijksoverheid/en/lifecyle/LifecycleOwnerExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/lifecyle/LifecycleOwnerExt.kt
@@ -4,13 +4,14 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.lifecyle
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
-
 fun LifecycleOwner.asFlow() = callbackFlow {
     val observer = object : DefaultLifecycleObserver {
         override fun onCreate(owner: LifecycleOwner) {

--- a/app/src/main/java/nl/rijksoverheid/en/navigation/NavBackStackEntryExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/navigation/NavBackStackEntryExt.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.navigation
 
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/java/nl/rijksoverheid/en/notification/PostNotificationViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/notification/PostNotificationViewModel.kt
@@ -32,7 +32,8 @@ class PostNotificationViewModel(
 
     fun setExposureNotificationGuidanceArgs(exposureDate: LocalDate, notificationReceivedDate: LocalDate?) {
         this.exposureNotificationGuidanceArgs.value = ExposureNotificationGuidanceArgs(
-            exposureDate, notificationReceivedDate
+            exposureDate,
+            notificationReceivedDate
         )
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/GooglePlayServicesUpdateRequiredFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/GooglePlayServicesUpdateRequiredFragment.kt
@@ -43,8 +43,9 @@ class GooglePlayServicesUpdateRequiredFragment :
         }
 
         viewModel.isExposureNotificationApiUpToDate.observe(viewLifecycleOwner) { upToDate ->
-            if (upToDate)
+            if (upToDate) {
                 findNavController().popBackStack()
+            }
         }
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/OnboardingViewModel.kt
@@ -27,8 +27,9 @@ class OnboardingViewModel(
     val isExposureNotificationApiUpToDate: LiveData<Boolean> = _isExposureNotificationApiUpToDate
 
     fun finishOnboarding() {
-        if (privacyPolicyConsentGiven.value != true)
+        if (privacyPolicyConsentGiven.value != true) {
             return
+        }
 
         onboardingRepository.setHasCompletedOnboarding(true)
         (onboardingComplete as MutableLiveData).value = Event(Unit)

--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/PrivacyPolicyConsentFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/PrivacyPolicyConsentFragment.kt
@@ -66,7 +66,9 @@ class PrivacyPolicyConsentFragment : BaseFragment(R.layout.fragment_privacy_poli
                             binding.description.performClick()
                         }
                     },
-                    start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    start,
+                    end,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
                 setSpan(
                     TextAppearanceSpan(view.context, R.style.TextAppearance_App_Link),

--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/SkipConsentConfirmationDialogFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/SkipConsentConfirmationDialogFragment.kt
@@ -25,12 +25,14 @@ class SkipConsentConfirmationDialogFragment : DialogFragment() {
             .setMessage(R.string.onboarding_consent_skip_dialog_message)
             .setPositiveButton(R.string.onboarding_consent_skip_dialog_enable) { _, _ ->
                 findNavController().currentBackStackEntry?.savedStateHandle?.set(
-                    SKIP_CONSENT_RESULT, false
+                    SKIP_CONSENT_RESULT,
+                    false
                 )
             }
             .setNegativeButton(R.string.onboarding_consent_skip_dialog_skip) { _, _ ->
                 findNavController().currentBackStackEntry?.savedStateHandle?.set(
-                    SKIP_CONSENT_RESULT, true
+                    SKIP_CONSENT_RESULT,
+                    true
                 )
             }
         return builder.create()

--- a/app/src/main/java/nl/rijksoverheid/en/resource/ResourceBundleManager.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/resource/ResourceBundleManager.kt
@@ -34,10 +34,11 @@ class ResourceBundleManager(
     private suspend fun loadResourceBundle(
         refreshFromServer: Boolean = false
     ): ResourceBundle {
-        return if (useDefaultGuidance)
+        return if (useDefaultGuidance) {
             loadDefaultResourceBundle()
-        else
+        } else {
             getResourceBundleFromCacheOrNetwork(refreshFromServer) ?: loadDefaultResourceBundle()
+        }
     }
 
     private fun loadDefaultResourceBundle(): ResourceBundle {

--- a/app/src/main/java/nl/rijksoverheid/en/settings/PauseDurationBottomSheetFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/settings/PauseDurationBottomSheetFragment.kt
@@ -55,8 +55,9 @@ class PauseDurationBottomSheetFragment : BottomSheetDialogFragment() {
 
         binding.content.adapter = adapter
         adapter.setOnItemClickListener { item, _ ->
-            if (item !is PauseDurationItem)
+            if (item !is PauseDurationItem) {
                 return@setOnItemClickListener
+            }
 
             val until = LocalDateTime.now().plusHours(item.pauseDurationInHours.toLong())
 

--- a/app/src/main/java/nl/rijksoverheid/en/status/RemoveExposedMessageDialogFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/RemoveExposedMessageDialogFragment.kt
@@ -32,7 +32,8 @@ class RemoveExposedMessageDialogFragment : DialogFragment() {
             .setMessage(getString(R.string.status_dialog_remove_exposure_message))
             .setPositiveButton(R.string.status_dialog_remove_exposure_confirm) { _, _ ->
                 findNavController().currentBackStackEntry?.savedStateHandle?.set(
-                    REMOVE_EXPOSED_MESSAGE_RESULT, true
+                    REMOVE_EXPOSED_MESSAGE_RESULT,
+                    true
                 )
             }
             .setNegativeButton(R.string.status_dialog_remove_exposure_cancel, null)

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusFooterItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusFooterItem.kt
@@ -17,12 +17,14 @@ class StatusFooterItem(private val lastKeysProcessed: LocalDateTime?) : BaseBind
     override fun getLayout() = R.layout.item_status_footer
 
     override fun bind(viewBinding: ItemStatusFooterBinding, position: Int) {
-        viewBinding.lastKeysSynced.text = if (lastKeysProcessed != null)
+        viewBinding.lastKeysSynced.text = if (lastKeysProcessed != null) {
             viewBinding.root.context.getString(
-                R.string.status_last_keys_processed, lastKeysProcessed.formatDateTime(viewBinding.root.context)
+                R.string.status_last_keys_processed,
+                lastKeysProcessed.formatDateTime(viewBinding.root.context)
             )
-        else
+        } else {
             viewBinding.root.context.getString(R.string.status_no_keys_processed)
+        }
 
         viewBinding.appVersion.text = viewBinding.root.context.getString(
             R.string.status_app_version,

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusFragment.kt
@@ -116,8 +116,9 @@ class StatusFragment @JvmOverloads constructor(
         }
 
         statusViewModel.exposureNotificationApiUpdateRequired.observe(viewLifecycleOwner) { requireAnUpdate ->
-            if (requireAnUpdate)
+            if (requireAnUpdate) {
                 findNavController().navigateCatchingErrors(StatusFragmentDirections.actionUpdatePlayServices())
+            }
         }
     }
 
@@ -259,10 +260,11 @@ class StatusFragment @JvmOverloads constructor(
 
     private fun navigateToSharingKeys() {
         viewLifecycleOwner.lifecycle.coroutineScope.launchWhenResumed {
-            if (statusViewModel.hasIndependentKeySharing())
+            if (statusViewModel.hasIndependentKeySharing()) {
                 findNavController().navigateCatchingErrors(StatusFragmentDirections.actionKeySharingOptions())
-            else
+            } else {
                 findNavController().navigateCatchingErrors(StatusFragmentDirections.actionLabTest())
+            }
         }
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusHeaderItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusHeaderItem.kt
@@ -127,10 +127,11 @@ class StatusHeaderItem(
             object : HeaderViewState(
                 R.drawable.gradient_status_paused,
                 R.string.cd_status_paused,
-                if (headerState.pausedUntil.isAfter(LocalDateTime.now()))
+                if (headerState.pausedUntil.isAfter(LocalDateTime.now())) {
                     R.string.status_paused_headline
-                else
-                    R.string.status_paused_duration_reached_headline,
+                } else {
+                    R.string.status_paused_duration_reached_headline
+                },
                 icon = R.drawable.ic_status_paused,
                 enableActionLabel = R.string.status_en_api_disabled_enable,
                 enableAction = primaryAction,

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusHeaderItem.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusHeaderItem.kt
@@ -6,6 +6,7 @@
  */
 package nl.rijksoverheid.en.status
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.annotation.BoolRes
 import androidx.annotation.DrawableRes
@@ -47,6 +48,8 @@ class StatusHeaderItem(
         abstract fun getDescription(context: Context): String
     }
 
+    // After upgrading AGP lint is flagging some of the fields incorrectly unfortunately
+    @SuppressLint("ResourceType")
     private val viewState = when (headerState) {
         StatusViewModel.HeaderState.Active ->
             object : HeaderViewState(

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusSection.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusSection.kt
@@ -38,7 +38,7 @@ class StatusSection : Section() {
 
     fun updateNotifications(
         notificationStates: List<StatusViewModel.NotificationState>,
-        onAction: (StatusViewModel.NotificationState, NotificationAction) -> Unit,
+        onAction: (StatusViewModel.NotificationState, NotificationAction) -> Unit
     ) {
         if (this.notificationStates != notificationStates) {
             this.notificationStates = notificationStates
@@ -95,7 +95,8 @@ class StatusSection : Section() {
         if (isEmpty) {
             addAll(
                 listOf(
-                    headerGroup, notificationGroup,
+                    headerGroup,
+                    notificationGroup,
                     Section(
                         listOf(
                             StatusActionItem.About,

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusViewModel.kt
@@ -98,10 +98,11 @@ class StatusViewModel(
 
     val lastKeysProcessed = exposureNotificationsRepository.lastKeyProcessed()
         .map {
-            if (it != null && it > 0)
+            if (it != null && it > 0) {
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneId.systemDefault())
-            else
+            } else {
                 null
+            }
         }.asLiveData(viewModelScope.coroutineContext)
 
     val exposureNotificationApiUpdateRequired = liveData {
@@ -110,10 +111,11 @@ class StatusViewModel(
 
     suspend fun getAppointmentInfo(context: Context): AppointmentInfo {
         val appConfig = appConfigManager.getCachedConfigOrDefault()
-        val phoneNumber = if (exposureDetected)
+        val phoneNumber = if (exposureDetected) {
             appConfig.appointmentPhoneNumber
-        else
+        } else {
             context.getString(R.string.request_test_phone_number)
+        }
         return AppointmentInfo(
             phoneNumber = phoneNumber,
             website = appConfig.coronaTestURL
@@ -199,14 +201,14 @@ class StatusViewModel(
         is StatusResult.Unavailable,
         is StatusResult.UnknownError -> NotificationState.Error.ConsentRequired
         StatusResult.BluetoothDisabled -> {
-            if (keyProcessingOverdue)
+            if (keyProcessingOverdue) {
                 NotificationState.Error.ConsentRequired
-            else NotificationState.Error.BluetoothDisabled
+            } else NotificationState.Error.BluetoothDisabled
         }
         StatusResult.LocationPreconditionNotSatisfied -> {
-            if (keyProcessingOverdue)
+            if (keyProcessingOverdue) {
                 NotificationState.Error.ConsentRequired
-            else NotificationState.Error.LocationDisabled
+            } else NotificationState.Error.LocationDisabled
         }
         StatusResult.Enabled -> {
             when {

--- a/app/src/main/java/nl/rijksoverheid/en/util/DateFormatUtils.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/DateFormatUtils.kt
@@ -22,8 +22,9 @@ import java.util.Locale
  */
 fun LocalDate.formatDaysSince(context: Context, clock: Clock = Clock.systemDefaultZone()): String {
     val daysSince = ChronoUnit.DAYS.between(this, LocalDate.now(clock)).toInt()
-    return if (daysSince == 0) context.resources.getString(R.string.today) else
+    return if (daysSince == 0) context.resources.getString(R.string.today) else {
         context.resources.getQuantityString(R.plurals.days_ago, daysSince, daysSince)
+    }
 }
 
 /**

--- a/app/src/main/java/nl/rijksoverheid/en/util/HtmlTextView.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/HtmlTextView.kt
@@ -26,7 +26,7 @@ class HtmlTextView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
-    defStyleRes: Int = 0,
+    defStyleRes: Int = 0
 ) : MaterialTextView(context, attrs, defStyle, defStyleRes) {
 
     /**

--- a/app/src/main/java/nl/rijksoverheid/en/util/HtmlTextViewWidget.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/HtmlTextViewWidget.kt
@@ -46,7 +46,7 @@ class HtmlTextViewWidget @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
-    defStyleRes: Int = 0,
+    defStyleRes: Int = 0
 ) : LinearLayout(context, attrs, defStyle, defStyleRes) {
 
     // Reflects the full text shown in the subviews. Can only be set internally.
@@ -146,8 +146,9 @@ class HtmlTextViewWidget @JvmOverloads constructor(
      */
     fun enableHtmlLinks() {
         children.filterIsInstance(TextView::class.java).forEach { textView ->
-            if (textView.hasUrlSpans())
+            if (textView.hasUrlSpans()) {
                 textView.enableHtmlLinks()
+            }
         }
     }
 
@@ -156,8 +157,9 @@ class HtmlTextViewWidget @JvmOverloads constructor(
      */
     fun enableCustomLinks(onLinkClick: () -> Unit) {
         children.filterIsInstance(TextView::class.java).forEach { textView ->
-            if (textView.hasUrlSpans())
+            if (textView.hasUrlSpans()) {
                 textView.enableCustomLinks(onLinkClick)
+            }
         }
     }
 

--- a/app/src/main/java/nl/rijksoverheid/en/util/LocaleHelper.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/LocaleHelper.kt
@@ -23,7 +23,7 @@ class LocaleHelper private constructor(application: Application, private val set
     // Ensure systemLocale is set and ConfigurationChangedCallback is registered _before_
     // custom Locale is applied, as the system locale can not be reliably retrieved after
     // changing the app's Locale.
-    private var systemLocale: Locale = LocaleListCompat.getDefault()[0]
+    private var systemLocale: Locale = requireNotNull(LocaleListCompat.getDefault()[0])
 
     val isAppSetToDutch: Boolean
         get() = settings.isAppSetToDutch
@@ -43,7 +43,7 @@ class LocaleHelper private constructor(application: Application, private val set
 
         application.registerComponentCallbacks(
             ConfigurationChangedCallback { configuration ->
-                systemLocale = ConfigurationCompat.getLocales(configuration)[0]
+                systemLocale = requireNotNull(ConfigurationCompat.getLocales(configuration)[0])
                 applyLocale(application, localeToUse)
             }
         )

--- a/app/src/main/java/nl/rijksoverheid/en/util/LocationUtils.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/LocationUtils.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util
 
 import android.content.ActivityNotFoundException

--- a/app/src/main/java/nl/rijksoverheid/en/util/RetryUtil.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/RetryUtil.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util
 
 import androidx.annotation.Keep

--- a/app/src/main/java/nl/rijksoverheid/en/util/StringUtils.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/StringUtils.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util
 
 import androidx.core.text.BidiFormatter

--- a/app/src/main/java/nl/rijksoverheid/en/util/ext/AppMessageExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/ext/AppMessageExt.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util.ext
 
 import nl.rijksoverheid.en.api.model.AppMessage

--- a/app/src/main/java/nl/rijksoverheid/en/util/ext/PausedStateExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/ext/PausedStateExt.kt
@@ -16,7 +16,6 @@ import java.time.LocalDateTime
 fun LocalDateTime.formatPauseDuration(context: Context): String {
     val now = LocalDateTime.now()
     return if (isAfter(now)) {
-
         val (durationHours, durationMinutes) = durationHoursAndMinutes()
         val formattedDuration = when {
             durationHours > 0 && durationMinutes > 0 -> formattedHoursAndMinutes(durationHours, durationMinutes, context)

--- a/app/src/main/java/nl/rijksoverheid/en/util/ext/PausedStateExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/ext/PausedStateExt.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util.ext
 
 import android.content.Context

--- a/app/src/main/java/nl/rijksoverheid/en/util/ext/SharedPreferencesExt.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/ext/SharedPreferencesExt.kt
@@ -4,6 +4,8 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
+@file:Suppress("ktlint:filename")
+
 package nl.rijksoverheid.en.util.ext
 
 import android.content.SharedPreferences

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -180,6 +180,7 @@
     <plurals name="days_ago">
         <item quantity="one">il y a %d jour</item>
         <item quantity="other">il y a %d jours</item>
+        <item quantity="many">il y a %d jours</item>
     </plurals>
     <string name="dialog_error_api_not_available_title">Google Play Services a été mis à jour</string>
     <string name="dialog_error_api_not_available_message">Ce n\'est que si Google Play Services a été mis à jour que l\'on conserve les éventuels contacts avec le Covid-19. Veuillez réessayer plus tard.</string>
@@ -280,14 +281,17 @@
     <plurals name="pause_duration_hours_option_plurals">
         <item quantity="one">Mettre en pause pour %d heure</item>
         <item quantity="other">Mettre en pause pour %d heures</item>
+        <item quantity="many">Mettre en pause pour %d heures</item>
     </plurals>
     <plurals name="duration_hours_plurals">
         <item quantity="one">%d heure</item>
         <item quantity="other">%d heures</item>
+        <item quantity="many">%d heures</item>
     </plurals>
     <plurals name="duration_minutes_plurals">
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>
+        <item quantity="many">%d minutes</item>
     </plurals>
     <string name="status_partly_active_headline">L\'application est partiellement activée.</string>
     <string name="status_error_sync_issues_wifi_only"><![CDATA[L\'application n\'a pas de connexion à Internet. Voilà pourquoi l\'application n\'a <b>pas</b>pu contrôler pendant 24 heures si les personnes que vous avez rencontrées se sont par la suite avérées avoir le Covid-19. L\'application enregistre toutefois <b>bien</b> vos rencontres.<br/><br/><b>Connectez-vous au Wifi ou indiquez que l\'application peut utiliser les données mobiles.</b>]]></string>

--- a/app/src/test/java/nl/rijksoverheid/en/ExposureNotificationsRepositoryTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/ExposureNotificationsRepositoryTest.kt
@@ -173,7 +173,7 @@ private val MOCK_RISK_CALCULATION_PARAMS = RiskCalculationParameters(
         DaySinceOnsetToInfectiousness(11, 1),
         DaySinceOnsetToInfectiousness(12, 0),
         DaySinceOnsetToInfectiousness(13, 0),
-        DaySinceOnsetToInfectiousness(14, 0),
+        DaySinceOnsetToInfectiousness(14, 0)
 
     ),
     infectiousnessWhenDaysSinceOnsetMissing = Infectiousness.STANDARD,
@@ -1005,7 +1005,7 @@ class ExposureNotificationsRepositoryTest {
                 },
                 getAppConfig = { _, _ ->
                     AppConfig(1, 5, 0.0, coronaMelderDeactivated = "deactivated")
-                },
+                }
             )
 
             val context = ApplicationProvider.getApplicationContext<Application>()
@@ -1094,7 +1094,7 @@ class ExposureNotificationsRepositoryTest {
                 },
                 getAppConfig = { _, _ ->
                     AppConfig(BuildConfig.VERSION_CODE + 1, 5, 0.0)
-                },
+                }
             )
 
             val context = ApplicationProvider.getApplicationContext<Application>()
@@ -1139,7 +1139,7 @@ class ExposureNotificationsRepositoryTest {
                 },
                 getAppConfig = { _, _ ->
                     AppConfig(0, 5, 0.0)
-                },
+                }
             )
 
             val context = ApplicationProvider.getApplicationContext<Application>()
@@ -1188,7 +1188,9 @@ class ExposureNotificationsRepositoryTest {
 
                     override suspend fun getManifest(cacheStrategy: CacheStrategy?): Manifest =
                         Manifest(
-                            listOf(), "risk", "config"
+                            listOf(),
+                            "risk",
+                            "config"
                         )
 
                     override suspend fun getRiskCalculationParameters(
@@ -2025,7 +2027,7 @@ class ExposureNotificationsRepositoryTest {
         getManifest: (CacheStrategy?) -> Manifest = { throw NotImplementedError() },
         getRiskCalculationParameters: (String, CacheStrategy?) -> RiskCalculationParameters = { _, _ -> throw NotImplementedError() },
         getAppConfig: (String, CacheStrategy?) -> AppConfig = { _, _ -> throw NotImplementedError() },
-        getResourceBundle: (String, CacheStrategy?) -> ResourceBundle = { _, _ -> throw NotImplementedError() },
+        getResourceBundle: (String, CacheStrategy?) -> ResourceBundle = { _, _ -> throw NotImplementedError() }
     ): CdnService {
         return object : CdnService {
             override suspend fun getExposureKeySetFile(id: String): Response<ResponseBody> {

--- a/app/src/test/java/nl/rijksoverheid/en/applifecycle/AppLifecycleViewModelTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/applifecycle/AppLifecycleViewModelTest.kt
@@ -20,10 +20,9 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalStateException
 
 @RunWith(RobolectricTestRunner::class)
-class Test {
+class AppLifecycleViewModelTest {
 
     @Mock
     private lateinit var appLifecycleManager: AppLifecycleManager

--- a/app/src/test/java/nl/rijksoverheid/en/notifier/NotificationsRepositoryTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/notifier/NotificationsRepositoryTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -80,7 +80,7 @@ class NotificationsRepositoryTest {
         }
 
     @Test
-    fun `exposureNotificationsEnabled refreshes when app is started`() = runBlockingTest {
+    fun `exposureNotificationsEnabled refreshes when app is started`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Application>()
         val lifecycleOwner = ProcessLifecycleOwner.get()
         val notificationManager = context.getSystemService(NotificationManager::class.java)

--- a/app/src/test/java/nl/rijksoverheid/en/resource/ResourceBundleManagerTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/resource/ResourceBundleManagerTest.kt
@@ -374,7 +374,8 @@ class ResourceBundleManagerTest {
                 ResourceBundle.Guidance(
                     listOf(
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            null, null,
+                            null,
+                            null,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("relative_layout_key", "relative_layout_key"))
                         )
                     ),
@@ -411,17 +412,20 @@ class ResourceBundleManagerTest {
                 ResourceBundle.Guidance(
                     listOf(
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            null, 3,
+                            null,
+                            3,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("incorrect_key", "incorrect_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            4, 10,
+                            4,
+                            10,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("correct_key", "correct_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            11, null,
+                            11,
+                            null,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("incorrect_key", "incorrect_key"))
-                        ),
+                        )
                     ),
                     emptyList()
                 )
@@ -456,17 +460,20 @@ class ResourceBundleManagerTest {
                 ResourceBundle.Guidance(
                     listOf(
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            null, 3,
+                            null,
+                            3,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("incorrect_key", "incorrect_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            4, 10,
+                            4,
+                            10,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("icorrect_key", "icorrect_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            11, null,
+                            11,
+                            null,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("correct_key", "correct_key"))
-                        ),
+                        )
                     ),
                     emptyList()
                 )
@@ -501,17 +508,20 @@ class ResourceBundleManagerTest {
                 ResourceBundle.Guidance(
                     listOf(
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            null, 3,
+                            null,
+                            3,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("correct_key", "correct_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            4, 10,
+                            4,
+                            10,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("icorrect_key", "icorrect_key"))
                         ),
                         ResourceBundle.Guidance.RelativeExposureDayLayout(
-                            11, null,
+                            11,
+                            null,
                             listOf(ResourceBundle.Guidance.Element.Paragraph("incorrect_key", "incorrect_key"))
-                        ),
+                        )
                     ),
                     emptyList()
                 )
@@ -559,10 +569,11 @@ class ResourceBundleManagerTest {
             context,
             object : FakeResourceBundleCdnService(cacheBundle) {
                 override suspend fun getResourceBundle(id: String, cacheStrategy: CacheStrategy?): ResourceBundle {
-                    return if (cacheStrategy == CacheStrategy.CACHE_FIRST || cacheStrategy == CacheStrategy.CACHE_ONLY)
+                    return if (cacheStrategy == CacheStrategy.CACHE_FIRST || cacheStrategy == CacheStrategy.CACHE_ONLY) {
                         cacheBundle
-                    else
+                    } else {
                         updatedBundle
+                    }
                 }
             },
             useDefaultGuidance = false

--- a/app/src/tst/java/nl/rijksoverheid/en/beagle/BeagleHelperImpl.kt
+++ b/app/src/tst/java/nl/rijksoverheid/en/beagle/BeagleHelperImpl.kt
@@ -96,8 +96,9 @@ object BeagleHelperImpl : BeagleHelper {
                 items = (0..20).map { value -> RadioGroupOption(value.toString(), value) },
                 initiallySelectedItemId = testExposureDaysAgo.toString(),
                 onSelectionChanged = {
-                    if (it != null)
+                    if (it != null) {
                         testExposureDaysAgo = it.value
+                    }
                 },
                 id = testNotificationExposureDaysAgoId
             ),
@@ -110,7 +111,7 @@ object BeagleHelperImpl : BeagleHelper {
             DividerModule(),
             TextModule("Other", TextModule.Type.SECTION_HEADER),
             KeylineOverlaySwitchModule(),
-            DeviceInfoModule(),
+            DeviceInfoModule()
         )
     }
 
@@ -124,7 +125,8 @@ object BeagleHelperImpl : BeagleHelper {
                         "Previous exposure date: ${
                         previouslyKnownExposureDate?.format(DateTimeFormatter.ISO_LOCAL_DATE) ?: "none"
                         }",
-                        TextModule.Type.NORMAL, id = previouslyKnownExposureDateId
+                        TextModule.Type.NORMAL,
+                        id = previouslyKnownExposureDateId
                     ),
                     placement = Placement.Below(testNotificationExposureDaysAgoId)
                 )

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,18 @@ plugins {
 
 apply from: 'gradle/spotless.gradle'
 
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+
+tasks.named("dependencyUpdates").configure {
+    rejectVersionIf {
+        isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+    }
+}
+
 allprojects {
     afterEvaluate {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
@@ -23,10 +35,10 @@ allprojects {
 
         project.plugins.withId("com.android.base") {
             android {
-                compileSdkVersion 31
+                compileSdkVersion 32
                 defaultConfig {
                     minSdkVersion 23
-                    targetSdkVersion 31
+                    targetSdkVersion 32
                 }
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -1,92 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    //androidx/google dependency versions
-    ext.androidx_activity_version = "1.4.0"
-    ext.androidx_appcompat_version = "1.4.1"
-    ext.androidx_core_version = "1.7.0"
-    ext.arch_core_version = "2.1.0"
-    ext.androidx_espresso_version = "3.4.0"
-    ext.androidx_fragment_version = "1.4.1"
-    ext.androidx_lifecycle_version = "2.4.1"
-    ext.androidx_nav_version = "2.4.2"
-    ext.androidx_test_core_version = "1.4.0"
-    ext.androidx_test_ext_junit_version = "1.1.3"
-    ext.androidx_work_version = "2.7.1"
-    ext.coroutines_version = "1.5.2"
-    ext.kotlin_version = '1.6.10'
-    ext.play_services_base_version = "18.0.1"
-    ext.play_services_tasks_version = "18.0.1"
-    //3rd-party dependency versions
-    ext.groupie_version = "2.10.0"
-    ext.jdk15to18_version = "1.66"
-    ext.junit_version = "4.13.2"
-    ext.moshi_version = '1.13.0'
-    ext.mockito_version = '4.3.1'
-    ext.mockitokotlin_version = '4.0.0'
-    ext.okhttp3_version = "4.9.1"
-    ext.retrofit_version = "2.9.0"
-    ext.robolectric_version = '4.7.3'
-    ext.timber_version = "5.0.1"
-    ext.insetter_version = '0.6.1'
-
-    repositories {
-        google {
-            content {
-                includeGroup "com.google"
-                includeGroup "com.android"
-                includeGroupByRegex "com.google\\..*"
-                includeGroupByRegex "com.android\\..*"
-                includeGroupByRegex "androidx\\..*"
-            }
-        }
-        mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-            content {
-                includeGroup "com.github.triplet.gradle"
-            }
-        }
-    }
-
-    dependencies {
-        // Android build tools
-        classpath 'com.android.tools.build:gradle:7.0.4'
-        // Fladle: Testing Firebase Snapshot Releases
-        classpath "com.osacky.flank.gradle:fladle:0.11.0"
-        // Kotlin gradle plugin
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // Spotless (code formatting) plugin
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.6.1"
-        // Android navigation save arguments
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$androidx_nav_version"
-        // Gradle Play publisher: Release automation gradle plugin
-        classpath "com.github.triplet.gradle:play-publisher:3.6.0"
-        // Firebase app distribution
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:3.0.0'
-        // Huawei publish gradle plugin
-        classpath "ru.cian:huawei-publish-gradle-plugin:1.1.0"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+plugins {
+    alias(libs.plugins.versions)
+    alias(libs.plugins.versionCatalog)
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.spotless)
 }
 
 apply from: 'gradle/spotless.gradle'
 
 allprojects {
-    repositories {
-        google {
-            content {
-                includeGroup "com.google"
-                includeGroup "com.android"
-                includeGroupByRegex "com.google\\..*"
-                includeGroupByRegex "com.android\\..*"
-                includeGroupByRegex "androidx\\..*"
-            }
-        }
-        mavenCentral()
-    }
-
     afterEvaluate {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {

--- a/en-api/build.gradle
+++ b/en-api/build.gradle
@@ -40,7 +40,9 @@ dependencies {
     api project(":play-services-nearby-eap")
     implementation libs.kotlin.coroutines.android
     implementation libs.androidx.core
-    implementation libs.bundles.playServices
+    implementation(libs.bundles.playServices) {
+        exclude group: "androidx.fragment", module: "fragment"
+    }
     implementation libs.timber
 
     testImplementation libs.junit

--- a/en-api/build.gradle
+++ b/en-api/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    id 'jacoco'
+}
 apply from: rootProject.file("jacoco.gradle")
 
 android {
@@ -35,29 +37,13 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-
-    // Play services nearby ExposureNotification SDK (included as AAR file)
     api project(":play-services-nearby-eap")
+    implementation libs.kotlin.coroutines.android
+    implementation libs.androidx.core
+    implementation libs.bundles.playServices
+    implementation libs.timber
 
-    // Coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-
-    // AndroidX
-    implementation "androidx.core:core-ktx:$androidx_core_version"
-
-    // Google play services
-    implementation "com.google.android.gms:play-services-base:$play_services_base_version"
-    implementation "com.google.android.gms:play-services-basement:$play_services_base_version"
-    implementation "com.google.android.gms:play-services-tasks:$play_services_tasks_version"
-
-    // Timber logging
-    implementation "com.jakewharton.timber:timber:$timber_version"
-
-    // JUnit
-    testImplementation "junit:junit:$junit_version"
-    testImplementation "androidx.test:core:$androidx_test_core_version"
-
-    // Roboelectric test runner
-    testImplementation "org.robolectric:robolectric:$robolectric_version"
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.robolectric
 }

--- a/en-api/src/main/java/nl/rijksoverheid/en/enapi/ExposureNotificationApi.kt
+++ b/en-api/src/main/java/nl/rijksoverheid/en/enapi/ExposureNotificationApi.kt
@@ -44,7 +44,7 @@ interface ExposureNotificationApi {
      */
     suspend fun provideDiagnosisKeys(
         files: List<File>,
-        diagnosisKeysDataMapping: DiagnosisKeysDataMapping,
+        diagnosisKeysDataMapping: DiagnosisKeysDataMapping
     ): DiagnosisKeysResult
 
     /**

--- a/en-api/src/main/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApi.kt
+++ b/en-api/src/main/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApi.kt
@@ -169,7 +169,7 @@ class NearbyExposureNotificationApi(
      */
     override suspend fun provideDiagnosisKeys(
         files: List<File>,
-        diagnosisKeysDataMapping: DiagnosisKeysDataMapping,
+        diagnosisKeysDataMapping: DiagnosisKeysDataMapping
     ): DiagnosisKeysResult {
         return suspendCoroutine { c ->
             client.setDiagnosisKeysDataMapping(
@@ -238,10 +238,11 @@ class NearbyExposureNotificationApi(
             try {
                 // Parse version as string, extract first 2 chars to get the en module version, then
                 // convert back to a long for easy comparison.
-                if (it.toString().substring(0, 2).toLong() >= MINIMUM_EN_VERSION)
+                if (it.toString().substring(0, 2).toLong() >= MINIMUM_EN_VERSION) {
                     c.resume(UpdateToDateResult.UpToDate)
-                else
+                } else {
                     c.resume(UpdateToDateResult.RequiresAnUpdate)
+                }
             } catch (e: Exception) {
                 Timber.e(e, "Unable to parse version")
                 c.resume(UpdateToDateResult.UnknownError(e))
@@ -249,10 +250,11 @@ class NearbyExposureNotificationApi(
         }.addOnFailureListener {
             Timber.e(it, "Error getting version of ExposureNotificationApi")
 
-            if ((it as? ApiException)?.statusCode == CommonStatusCodes.API_NOT_CONNECTED)
+            if ((it as? ApiException)?.statusCode == CommonStatusCodes.API_NOT_CONNECTED) {
                 c.resume(UpdateToDateResult.RequiresAnUpdate)
-            else
+            } else {
                 c.resume(UpdateToDateResult.UnknownError(it))
+            }
         }
     }
 

--- a/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/FakeExposureNotificationsClient.kt
+++ b/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/FakeExposureNotificationsClient.kt
@@ -50,7 +50,7 @@ abstract class FakeExposureNotificationsClient : ExposureNotificationClient {
         throw NotImplementedError()
     }
 
-    override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping?): Task<Void> {
+    override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping): Task<Void> {
         throw NotImplementedError()
     }
 

--- a/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/FakeExposureNotificationsClient.kt
+++ b/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/FakeExposureNotificationsClient.kt
@@ -4,7 +4,7 @@
  *
  *  SPDX-License-Identifier: EUPL-1.2
  */
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 
 package nl.rijksoverheid.en.enapi.nearby
 
@@ -66,10 +66,11 @@ abstract class FakeExposureNotificationsClient : ExposureNotificationClient {
         throw NotImplementedError()
     }
 
-    override fun getDailySummaries(p0: DailySummariesConfig?): Task<MutableList<DailySummary>> {
+    override fun getDailySummaries(p0: DailySummariesConfig): Task<MutableList<DailySummary>> {
         throw NotImplementedError()
     }
 
+    @Deprecated("Deprecated in Java")
     @Suppress("DEPRECATION")
     override fun getExposureSummary(token: String): Task<ExposureSummary> =
         Tasks.forException(IllegalStateException())
@@ -78,6 +79,7 @@ abstract class FakeExposureNotificationsClient : ExposureNotificationClient {
 
     override fun stop(): Task<Void> = Tasks.forException(IllegalStateException())
 
+    @Deprecated("Deprecated in Java")
     @Suppress("DEPRECATION")
     override fun getExposureInformation(token: String): Task<List<ExposureInformation>> =
         Tasks.forException(IllegalStateException())
@@ -89,7 +91,8 @@ abstract class FakeExposureNotificationsClient : ExposureNotificationClient {
     override fun getTemporaryExposureKeyHistory(): Task<List<TemporaryExposureKey>> =
         Tasks.forException(IllegalStateException())
 
-    override fun getExposureWindows(token: String?): Task<MutableList<ExposureWindow>> =
+    @Deprecated("Deprecated in Java")
+    override fun getExposureWindows(token: String): Task<MutableList<ExposureWindow>> =
         Tasks.forException(IllegalStateException())
 
     override fun getStatus(): Task<MutableSet<ExposureNotificationStatus>> =

--- a/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApiTest.kt
+++ b/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApiTest.kt
@@ -477,7 +477,7 @@ class NearbyExposureNotificationApiTest {
         // WHEN
         val status = api.provideDiagnosisKeys(
             listOf(file),
-            diagnosisKeysDataMapping,
+            diagnosisKeysDataMapping
         )
 
         // THEN
@@ -510,7 +510,7 @@ class NearbyExposureNotificationApiTest {
                 // WHEN
                 val status = api.provideDiagnosisKeys(
                     listOf(file),
-                    diagnosisKeysDataMapping,
+                    diagnosisKeysDataMapping
                 )
 
                 // THEN
@@ -547,7 +547,7 @@ class NearbyExposureNotificationApiTest {
                 // WHEN
                 val status = api.provideDiagnosisKeys(
                     listOf(file),
-                    diagnosisKeysDataMapping,
+                    diagnosisKeysDataMapping
                 )
 
                 // THEN

--- a/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApiTest.kt
+++ b/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApiTest.kt
@@ -51,7 +51,7 @@ import java.io.File
 import java.time.LocalDate
 import java.time.ZoneId
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "BlockingMethodInNonBlockingContext")
 @LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.O_MR1])
@@ -468,7 +468,7 @@ class NearbyExposureNotificationApiTest {
                     override fun provideDiagnosisKeys(files: List<File>): Task<Void> {
                         return Tasks.forResult(null)
                     }
-                    override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping?): Task<Void> {
+                    override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping): Task<Void> {
                         return Tasks.forResult(null)
                     }
                 }
@@ -500,7 +500,7 @@ class NearbyExposureNotificationApiTest {
                         override fun provideDiagnosisKeys(files: List<File>): Task<Void> {
                             return Tasks.forException(exception)
                         }
-                        override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping?): Task<Void> {
+                        override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping): Task<Void> {
                             return Tasks.forResult(null)
                         }
                     }
@@ -537,7 +537,7 @@ class NearbyExposureNotificationApiTest {
                         override fun provideDiagnosisKeys(files: List<File>): Task<Void> {
                             return Tasks.forException(exception)
                         }
-                        override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping?): Task<Void> {
+                        override fun setDiagnosisKeysDataMapping(p0: DiagnosisKeysDataMapping): Task<Void> {
                             return Tasks.forResult(null)
                         }
                     }

--- a/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/RiskModelTest.kt
+++ b/en-api/src/test/java/nl/rijksoverheid/en/enapi/nearby/RiskModelTest.kt
@@ -85,7 +85,7 @@ class RiskModelTest {
                         listOf(
                             ScanInstance.Builder()
                                 .setSecondsSinceLastScan(600)
-                                .setTypicalAttenuationDb(57).build(),
+                                .setTypicalAttenuationDb(57).build()
                         )
                     )
                     .build(),
@@ -239,7 +239,7 @@ class RiskModelTest {
                                 .setTypicalAttenuationDb(57).build(),
                             ScanInstance.Builder()
                                 .setSecondsSinceLastScan(60)
-                                .setTypicalAttenuationDb(55).build(),
+                                .setTypicalAttenuationDb(55).build()
                         )
                     )
                     .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,43 +1,44 @@
 [versions]
-androidx-activity = "1.4.0"
-androidx-appcompat = "1.4.1"
+agp = "7.2.1"
+androidx-activity = "1.5.1"
+androidx-appcompat = "1.4.2"
 androidx-arch-core = "2.1.0"
-androidx-fragment = "1.4.1"
-androidx-navigation = "2.4.2"
+androidx-fragment = "1.5.1"
+androidx-navigation = "2.5.1"
 androidx-preference = "1.2.0"
 androidx-test = "1.4.0"
 androidx-test-espresso = "3.4.0"
 androidx-work = "2.7.1"
-beagle = "2.5.1"
-bouncycastle = "1.66"
-groupie = "2.10.0"
-kotlin = "1.6.10"
-mockito = "4.3.1"
+beagle = "2.7.3"
+bouncycastle = "1.70"
+groupie = "2.10.1"
+kotlin = "1.7.10"
+kotlin-coroutines = "1.6.4"
+mockito = "4.6.1"
 moshi = "1.13.0"
 okhttp3 = "4.9.1"
-kotlin-coroutines = "1.5.2"
-play-services = "18.0.1"
+play-services = "18.1.0"
 retrofit2 = "2.9.0"
 
 [libraries]
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-browser = "androidx.browser:browser:1.4.0"
-androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.3"
-androidx-core = "androidx.core:core-ktx:1.7.0"
+androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.4"
+androidx-core = "androidx.core:core-ktx:1.8.0"
 androidx-core-splashscreen = "androidx.core:core-splashscreen:1.0.0-beta02"
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.4.1"
-androidx-lifecycle-common-java8 = "androidx.lifecycle:lifecycle-common-java8:2.4.1"
+androidx-lifecycle-common-java8 = "androidx.lifecycle:lifecycle-common-java8:2.5.1"
 androidx-lifecycle-extensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
-androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
+androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
 androidx-lifecycle-livedata-core = "androidx.lifecycle:lifecycle-livedata-core-ktx:2.4.1"
-androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.4.1"
+androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.5.1"
 androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
 androidx-lifecycle-runtime-testing = "androidx.lifecycle:lifecycle-runtime-testing:2.3.1"
 androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.2.0"
-androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 androidx-lifecycle-viewmodel-savedstate = "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidx-navigation" }
@@ -56,11 +57,10 @@ androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk15to18", version.ref = "bouncycastle" }
 bcprov = { module = "org.bouncycastle:bcprov-jdk15to18", version.ref = "bouncycastle" }
 beagle-ui-drawer = { module = "com.github.pandulapeter.beagle:ui-drawer", version.ref = "beagle" }
-desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
+# @pin this version, higher versions require a newer (beta/alpha) AGP version
+desugar = "com.android.tools:desugar_jdk_libs:1.1.6"
 disableAnimationsRule = "com.github.blipinsk:disable-animations-rule:2.0.0"
 fastlane-screengrab = "tools.fastlane:screengrab:2.1.1"
-firebase-appdistribution-gradle = "com.google.firebase:firebase-appdistribution-gradle:3.0.0"
-fladle = "com.osacky.flank.gradle:fladle:0.11.0"
 groupie = { module = "com.github.lisawray.groupie:groupie", version.ref = "groupie" }
 groupie-viewbinding = { module = "com.github.lisawray.groupie:groupie-viewbinding", version.ref = "groupie" }
 insetter = "dev.chrisbanes.insetter:insetter:0.6.1"
@@ -68,8 +68,8 @@ junit = "junit:junit:4.13.2"
 junit4AndroidIntegrationRules = "com.vanniktech:junit4-android-integration-rules:0.3.0"
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-testing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
-lottie = "com.airbnb.android:lottie:4.2.2"
-material = "com.google.android.material:material:1.5.0"
+lottie = "com.airbnb.android:lottie:5.2.0"
+material = "com.google.android.material:material:1.6.1"
 mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockito" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
@@ -79,17 +79,17 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
-okhttp3-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp3" }
+okhttp3-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.10.0"
+okhttp3-tls = "com.squareup.okhttp3:okhttp-tls:4.10.0"
 okio = "com.squareup.okio:okio:2.10.0"
 play-core = "com.google.android.play:core:1.10.3"
 play-core-ktx = "com.google.android.play:core-ktx:1.8.1"
 playServices-base = { module = "com.google.android.gms:play-services-base", version.ref = "play-services" }
 playServices-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services" }
-playServices-tasks = { module = "com.google.android.gms:play-services-tasks", version.ref = "play-services" }
+playServices-tasks = "com.google.android.gms:play-services-tasks:18.0.2"
 retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
 retrofit2-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit2" }
-robolectric = "org.robolectric:robolectric:4.7.3"
+robolectric = "org.robolectric:robolectric:4.8.1"
 timber = "com.jakewharton.timber:timber:5.0.1"
 tink-android = "com.google.crypto.tink:tink-android:1.5.0"
 
@@ -114,15 +114,15 @@ playServices = [
 ]
 
 [plugins]
-android-application = "com.android.application:7.0.4"
-android-library = "com.android.library:7.0.4"
-firebase-appdistribution = "com.google.firebase.appdistribution:3.0.0"
-fladle = "com.osacky.fladle:0.11.0"
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+firebase-appdistribution = "com.google.firebase.appdistribution:3.0.2"
+fladle = "com.osacky.fladle:0.17.4"
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-navigation-safeargs = "androidx.navigation.safeargs.kotlin:2.4.2"
-spotless = "com.diffplug.spotless:5.6.1"
-tripletPlay = "com.github.triplet.play:3.6.0"
+navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
+spotless = "com.diffplug.spotless:6.9.0"
+tripletPlay = "com.github.triplet.play:3.7.0"
 versionCatalog = "nl.littlerobots.version-catalog-update:0.5.3"
-versions = "com.github.ben-manes.versions:0.41.0"
+versions = "com.github.ben-manes.versions:0.42.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,128 @@
+[versions]
+androidx-activity = "1.4.0"
+androidx-appcompat = "1.4.1"
+androidx-arch-core = "2.1.0"
+androidx-fragment = "1.4.1"
+androidx-navigation = "2.4.2"
+androidx-preference = "1.2.0"
+androidx-test = "1.4.0"
+androidx-test-espresso = "3.4.0"
+androidx-work = "2.7.1"
+beagle = "2.5.1"
+bouncycastle = "1.66"
+groupie = "2.10.0"
+kotlin = "1.6.10"
+mockito = "4.3.1"
+moshi = "1.13.0"
+okhttp3 = "4.9.1"
+kotlin-coroutines = "1.5.2"
+play-services = "18.0.1"
+retrofit2 = "2.9.0"
+
+[libraries]
+androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-browser = "androidx.browser:browser:1.4.0"
+androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.3"
+androidx-core = "androidx.core:core-ktx:1.7.0"
+androidx-core-splashscreen = "androidx.core:core-splashscreen:1.0.0-beta02"
+androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core" }
+androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.4.1"
+androidx-lifecycle-common-java8 = "androidx.lifecycle:lifecycle-common-java8:2.4.1"
+androidx-lifecycle-extensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
+androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
+androidx-lifecycle-livedata-core = "androidx.lifecycle:lifecycle-livedata-core-ktx:2.4.1"
+androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.4.1"
+androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+androidx-lifecycle-runtime-testing = "androidx.lifecycle:lifecycle-runtime-testing:2.3.1"
+androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.2.0"
+androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+androidx-lifecycle-viewmodel-savedstate = "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
+androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
+androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidx-navigation" }
+androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
+androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
+androidx-security-crypto = "androidx.security:security-crypto:1.1.0-alpha03"
+androidx-startup-runtime = "androidx.startup:startup-runtime:1.1.1"
+androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "androidx-test" }
+androidx-test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-test-espresso" }
+androidx-test-junit = "androidx.test.ext:junit:1.1.3"
+androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
+androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
+androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
+bcpkix = { module = "org.bouncycastle:bcpkix-jdk15to18", version.ref = "bouncycastle" }
+bcprov = { module = "org.bouncycastle:bcprov-jdk15to18", version.ref = "bouncycastle" }
+beagle-ui-drawer = { module = "com.github.pandulapeter.beagle:ui-drawer", version.ref = "beagle" }
+desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
+disableAnimationsRule = "com.github.blipinsk:disable-animations-rule:2.0.0"
+fastlane-screengrab = "tools.fastlane:screengrab:2.1.1"
+firebase-appdistribution-gradle = "com.google.firebase:firebase-appdistribution-gradle:3.0.0"
+fladle = "com.osacky.flank.gradle:fladle:0.11.0"
+groupie = { module = "com.github.lisawray.groupie:groupie", version.ref = "groupie" }
+groupie-viewbinding = { module = "com.github.lisawray.groupie:groupie-viewbinding", version.ref = "groupie" }
+insetter = "dev.chrisbanes.insetter:insetter:0.6.1"
+junit = "junit:junit:4.13.2"
+junit4AndroidIntegrationRules = "com.vanniktech:junit4-android-integration-rules:0.3.0"
+kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
+kotlin-coroutines-testing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
+lottie = "com.airbnb.android:lottie:4.2.2"
+material = "com.google.android.material:material:1.5.0"
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockito" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
+moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
+okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
+okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
+okhttp3-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp3" }
+okio = "com.squareup.okio:okio:2.10.0"
+play-core = "com.google.android.play:core:1.10.3"
+play-core-ktx = "com.google.android.play:core-ktx:1.8.1"
+playServices-base = { module = "com.google.android.gms:play-services-base", version.ref = "play-services" }
+playServices-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services" }
+playServices-tasks = { module = "com.google.android.gms:play-services-tasks", version.ref = "play-services" }
+retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
+retrofit2-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit2" }
+robolectric = "org.robolectric:robolectric:4.7.3"
+timber = "com.jakewharton.timber:timber:5.0.1"
+tink-android = "com.google.crypto.tink:tink-android:1.5.0"
+
+[bundles]
+espresso = [
+    "androidx-test-espresso-contrib",
+    "androidx-test-espresso-core",
+    "androidx-test-espresso-intents",
+]
+groupie = [
+    "groupie",
+    "groupie-viewbinding",
+]
+play-core = [
+    "play-core",
+    "play-core-ktx",
+]
+playServices = [
+    "playServices-base",
+    "playServices-basement",
+    "playServices-tasks",
+]
+
+[plugins]
+android-application = "com.android.application:7.0.4"
+android-library = "com.android.library:7.0.4"
+firebase-appdistribution = "com.google.firebase.appdistribution:3.0.0"
+fladle = "com.osacky.fladle:0.11.0"
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+navigation-safeargs = "androidx.navigation.safeargs.kotlin:2.4.2"
+spotless = "com.diffplug.spotless:5.6.1"
+tripletPlay = "com.github.triplet.play:3.6.0"
+versionCatalog = "nl.littlerobots.version-catalog-update:0.5.3"
+versions = "com.github.ben-manes.versions:0.41.0"

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -1,4 +1,4 @@
-apply plugin: "com.diffplug.spotless"
+//apply plugin: "com.diffplug.spotless"
 
 spotless {
     format 'misc', {

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,7 +9,7 @@ spotless {
         endWithNewline()
     }
     kotlin {
-        ktlint("0.39.0")
+        ktlint("0.46.1")
         target "**/src/**/*.kt"
         // keep original license of this file
         targetExclude 'app/src/main/java/nl/rijksoverheid/en/lifecyle/Event.kt'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -30,8 +30,8 @@ project.afterEvaluate {
             description = "Generate Jacoco coverage reports for the ${variantName.capitalize()} build."
 
             reports {
-                html.enabled = true
-                xml.enabled = true
+                html.required = true
+                xml.required = true
             }
 
             def excludes = [

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -5,8 +5,6 @@
  *   SPDX-License-Identifier: EUPL-1.2
  *
  */
-apply plugin: 'jacoco'
-
 jacoco {
     toolVersion = '0.8.7'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,44 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroup "com.google"
+                includeGroup "com.android"
+                includeGroupByRegex "com.google\\..*"
+                includeGroupByRegex "com.android\\..*"
+                includeGroupByRegex "androidx\\..*"
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google {
+            content {
+                includeGroup "com.google"
+                includeGroup "com.android"
+                includeGroupByRegex "com.google\\..*"
+                includeGroupByRegex "com.android\\..*"
+                includeGroupByRegex "androidx\\..*"
+            }
+        }
+        mavenCentral()
+
+        maven {
+            url "https://jitpack.io"
+            content {
+                includeGroup "com.github.pandulapeter.beagle"
+                includeGroup "com.github.blipinsk"
+                includeGroup "com.github.lisawray.groupie"
+            }
+        }
+    }
+}
+
 include ':signing'
 include ':test-support'
 include ':en-api'

--- a/signing/build.gradle
+++ b/signing/build.gradle
@@ -5,9 +5,11 @@
  *   SPDX-License-Identifier: EUPL-1.2
  *
  */
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    id 'jacoco'
+}
 apply from: rootProject.file("jacoco.gradle")
 
 android {
@@ -26,15 +28,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-
-    // AndroidX
-    implementation "androidx.core:core-ktx:$androidx_core_version"
-
-    // Bouncy Castle Provider
-    implementation "org.bouncycastle:bcprov-jdk15to18:$jdk15to18_version"
-    api "org.bouncycastle:bcpkix-jdk15to18:$jdk15to18_version"
-
-    // JUnit
-    testImplementation "junit:junit:$junit_version"
+    implementation libs.androidx.core
+    implementation libs.bcprov
+    api libs.bcpkix
+    testImplementation libs.junit
 }

--- a/signing/src/main/java/nl/rijksoverheid/en/signing/ResponseSignatureValidator.kt
+++ b/signing/src/main/java/nl/rijksoverheid/en/signing/ResponseSignatureValidator.kt
@@ -76,7 +76,8 @@ class ResponseSignatureValidator(
             val sp = CMSSignedDataParser(
                 JcaDigestCalculatorProviderBuilder().setProvider(provider)
                     .build(),
-                CMSTypedStream(BufferedInputStream(content)), signature
+                CMSTypedStream(BufferedInputStream(content)),
+                signature
             )
 
             sp.signedContent.drain()

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,8 +1,9 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
 
 android {
-
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -17,16 +18,14 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-
-    api 'androidx.test:core-ktx:1.4.0'
-    api "androidx.fragment:fragment-ktx:$androidx_fragment_version"
+    api libs.androidx.test.core
+    api libs.androidx.fragment
 
     implementation project(":en-api")
 
-    implementation "androidx.activity:activity-ktx:$androidx_activity_version"
-    implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
-    implementation "androidx.navigation:navigation-testing:$androidx_nav_version"
+    implementation libs.androidx.activity
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.navigation.testing
 
-    implementation "dev.chrisbanes.insetter:insetter:$insetter_version"
+    implementation libs.insetter
 }


### PR DESCRIPTION
* Move all dependencies to a version catalog
* Bump relevant dependencies and fix Kotlin warnings
* Bumped compile and target API to latest Android SDK version (32)
* Fix an issue within the IDE showing errors in `MainActivity` due to (very old) version of `androidx.fragment` being pulled in.
* Update ktlint, which (unfortunately) introduces new rules. Some of the file naming lints did not quite make sense to me, so I've suppressed those and only fixed `AppLifecycleViewModelTest` which was incorrectly named `Test` before. Ran `./gradlew spotlessApply` to fix formatting, which mainly seems to be brackets on multiline if statements.
* Fix (new) lint warning for the French translations, missing a plural entry
* Bump app version
* Removed Huawei app store publishing plugin (app isn't published to that store for about a year)