### PR TITLE
Remove Huawei app store check

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
@@ -128,12 +128,8 @@ class MainActivity : AppCompatActivity() {
             if (!navController.isInitialised()) {
                 inflateNavGraph(R.id.nav_app_update_required)
             } else {
-                val installerPackageName =
-                    (update as AppLifecycleManager.UpdateState.UpdateRequired).installerPackageName
                 navController.navigate(
-                    AppUpdateRequiredFragmentDirections.actionAppUpdateRequired(
-                        installerPackageName
-                    )
+                    AppUpdateRequiredFragmentDirections.actionAppUpdateRequired()
                 )
             }
         }

--- a/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppLifecycleManager.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppLifecycleManager.kt
@@ -54,7 +54,7 @@ class AppLifecycleManager(
      */
     suspend fun getUpdateState(): UpdateState {
         return if (minimumVersionCode > currentVersionCode) {
-            when (val source = getInstallPackageName()) {
+            when (getInstallPackageName()) {
                 PLAY_STORE_PACKAGE_NAME -> {
                     try {
                         val appUpdateInfo = appUpdateManager.requestAppUpdateInfo()
@@ -69,10 +69,11 @@ class AppLifecycleManager(
                         }
                     } catch (e: Exception) {
                         Timber.e("requestAppUpdateInfo failed", e)
-                        UpdateState.UpdateRequired(source)
+                        UpdateState.UpdateRequired
                     }
                 }
-                else -> UpdateState.UpdateRequired(source)
+                // side loaded, or previously from another app store
+                else -> UpdateState.UpdateRequired
             }
         } else {
             UpdateState.UpToDate
@@ -85,7 +86,7 @@ class AppLifecycleManager(
             val appUpdateInfo: AppUpdateInfo
         ) : UpdateState()
 
-        data class UpdateRequired(val installerPackageName: String?) : UpdateState()
+        object UpdateRequired : UpdateState()
 
         data class Error(val ex: Exception) : UpdateState()
 

--- a/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppUpdateRequiredFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/applifecycle/AppUpdateRequiredFragment.kt
@@ -6,25 +6,16 @@
  */
 package nl.rijksoverheid.en.applifecycle
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
-import androidx.navigation.fragment.navArgs
 import nl.rijksoverheid.en.BaseFragment
 import nl.rijksoverheid.en.BuildConfig
 import nl.rijksoverheid.en.R
 import nl.rijksoverheid.en.databinding.FragmentAppUpdateRequiredBinding
 import nl.rijksoverheid.en.util.IntentHelper
-import timber.log.Timber
-
-private const val APP_GALLERY_PACKAGE = "com.huawei.appmarket"
 
 class AppUpdateRequiredFragment : BaseFragment(R.layout.fragment_app_update_required) {
-    private val args: AppUpdateRequiredFragmentArgs by navArgs()
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentAppUpdateRequiredBinding.bind(view)
@@ -34,26 +25,7 @@ class AppUpdateRequiredFragment : BaseFragment(R.layout.fragment_app_update_requ
         }
 
         binding.next.setOnClickListener {
-            openAppStore()
-        }
-    }
-
-    private fun openAppStore() {
-        when (args.appStorePackage) {
-            APP_GALLERY_PACKAGE -> openAppGallery()
-            else -> IntentHelper.openPlayStore(requireActivity(), BuildConfig.APPLICATION_ID)
-        }
-    }
-
-    private fun openAppGallery() {
-        val intent = Intent(
-            Intent.ACTION_VIEW,
-            Uri.parse("appmarket://details?id=${BuildConfig.APPLICATION_ID}")
-        ).addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY or Intent.FLAG_ACTIVITY_NEW_TASK)
-        try {
-            requireActivity().startActivity(intent)
-        } catch (ex: ActivityNotFoundException) {
-            Timber.w("Could not open app gallery!")
+            IntentHelper.openPlayStore(requireActivity(), BuildConfig.APPLICATION_ID)
         }
     }
 }

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -365,10 +365,6 @@
         android:id="@+id/nav_app_update_required"
         android:name="nl.rijksoverheid.en.applifecycle.AppUpdateRequiredFragment"
         tools:layout="@layout/fragment_app_update_required">
-        <argument
-            android:name="app_store_package"
-            app:argType="string"
-            app:nullable="true" />
     </fragment>
 
     <fragment

--- a/app/src/test/java/nl/rijksoverheid/en/applifecycle/AppLifecycleManagerTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/applifecycle/AppLifecycleManagerTest.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -69,9 +68,5 @@ class AppLifecycleManagerTest {
             val result = appLifecycleManager.getUpdateState()
 
             assertTrue(result is AppLifecycleManager.UpdateState.UpdateRequired)
-            assertEquals(
-                "com.some.appstore",
-                (result as AppLifecycleManager.UpdateState.UpdateRequired).installerPackageName
-            )
         }
 }


### PR DESCRIPTION
As the app is no longer being published to the Huawei app store, this check can be removed.
The update screen CTA will redirect to the Play Store if possible all devices.