### PR TITLE
Replace kapt for moshi with ksp

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     id 'jacoco'
 }
 apply from: rootProject.file("jacoco.gradle")
@@ -76,6 +76,15 @@ android {
     }
 
     compileOptions.coreLibraryDesugaringEnabled true
+
+    kotlin {
+        sourceSets.main {
+            kotlin.srcDir("build/generated/ksp/main/kotlin")
+        }
+        sourceSets.test {
+            kotlin.srcDir("build/generated/ksp/test/kotlin")
+        }
+    }
 }
 
 dependencies {
@@ -90,7 +99,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-reflect"
     }
     implementation libs.moshi.adapters
-    kapt libs.moshi.kotlin.codegen
+    ksp libs.moshi.kotlin.codegen
     implementation libs.timber
 
     testImplementation libs.junit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-work = "2.7.1"
 beagle = "2.7.3"
 bouncycastle = "1.70"
 groupie = "2.10.1"
+# @pin update manually
 kotlin = "1.7.10"
 kotlin-coroutines = "1.6.4"
 mockito = "4.6.1"
@@ -121,6 +122,8 @@ fladle = "com.osacky.fladle:0.17.4"
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+# @pin to kotlin version
+ksp = "com.google.devtools.ksp:1.7.10-1.0.6"
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
 spotless = "com.diffplug.spotless:6.9.0"
 tripletPlay = "com.github.triplet.play:3.7.0"


### PR DESCRIPTION
This speeds up the build a little by eliminating `kapt`, though the app module still needs it for databinding, so we cannot get rid of all `kapt` occurences.