### PR TITLE
Fix dashboard scrolling

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardOverviewSection.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardOverviewSection.kt
@@ -19,8 +19,11 @@ import nl.rijksoverheid.en.status.items.LoadingItem
 
 class DashboardOverviewSection : Section() {
 
+    private val overviewItems = Section()
+
     init {
         setPlaceholder(LoadingItem())
+        add(overviewItems)
     }
 
     fun updateDashboardData(
@@ -32,7 +35,7 @@ class DashboardOverviewSection : Section() {
             .sortedBy { it.sortingValue }
             .map { dashboardItem -> DashboardCardItem(context, dashboardItem) }
 
-        update(
+        overviewItems.update(
             listOf(
                 HeaderItem(R.string.dashboard_header),
                 TagItem(R.string.dashboard_tag),

--- a/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardSection.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardSection.kt
@@ -24,8 +24,11 @@ import nl.rijksoverheid.en.util.formatToString
 
 class DashboardSection : Section() {
 
+    private val dashboardItems = Section()
+
     init {
         setPlaceholder(LoadingItem())
+        add(dashboardItems)
     }
 
     fun updateDashboardData(
@@ -80,7 +83,7 @@ class DashboardSection : Section() {
             .filter { it.reference != selectedDashboardItem }
             .map { DashboardLinkItem(it, onDashboardLinkItemClicked) }
 
-        update(items)
+        dashboardItems.update(items)
     }
 
     private fun MovingAverage.toSummaryArgs(context: Context) = listOf(


### PR DESCRIPTION
Use a nested section to prevent incorrect initial scrolling position for the dashboard overview and dashboard details.

## Before

https://user-images.githubusercontent.com/866834/183908494-8de95aba-57b4-4ac1-805d-a3ff364861ec.mp4

## After

https://user-images.githubusercontent.com/866834/183908521-186ccbe8-7837-4853-897e-197c0a011ca8.mp4


