### PR TITLE
Fix dashboard transitions

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardFragment.kt
@@ -10,10 +10,11 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.navigation.navGraphViewModels
+import androidx.transition.TransitionInflater
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
 import nl.rijksoverheid.en.BaseFragment
@@ -21,7 +22,6 @@ import nl.rijksoverheid.en.R
 import nl.rijksoverheid.en.api.model.DashboardItemRef
 import nl.rijksoverheid.en.databinding.FragmentListBinding
 import nl.rijksoverheid.en.navigation.navigateCatchingErrors
-import nl.rijksoverheid.en.util.ext.setExitSlideTransition
 import nl.rijksoverheid.en.util.ext.setSlideTransition
 
 /**
@@ -31,7 +31,7 @@ class DashboardFragment : BaseFragment(R.layout.fragment_list) {
 
     private val args: DashboardFragmentArgs by navArgs()
 
-    private val viewModel: DashboardViewModel by viewModels()
+    private val viewModel: DashboardViewModel by navGraphViewModels(R.id.nav_dashboard, factoryProducer = { defaultViewModelProviderFactory })
     private val adapter = GroupAdapter<GroupieViewHolder>()
     private val section = DashboardSection().also {
         adapter.add(it)
@@ -42,10 +42,25 @@ class DashboardFragment : BaseFragment(R.layout.fragment_list) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (args.showEnterTransition) {
-            setSlideTransition()
+        if (args.fromDeeplink) {
+            // from deeplink only exit is to dashboard item --> fade
+            exitTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.short_fade)
+            // return to overview --> slide + shared element
+            returnTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.slide_end)
+            // no shared element enter
+            sharedElementReturnTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.move_fade)
+        } else if (args.fromDashboardItem) {
+            enterTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.short_fade)
+            exitTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.short_fade)
+            // back to overview
+            returnTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.slide_end)
+            sharedElementEnterTransition =
+                TransitionInflater.from(requireContext()).inflateTransition(R.transition.move_fade)
+            sharedElementReturnTransition = sharedElementEnterTransition
         } else {
-            setExitSlideTransition()
+            setSlideTransition()
+            // exit to dashboard item --> fade
+            exitTransition = TransitionInflater.from(requireContext()).inflateTransition(R.transition.short_fade)
         }
     }
 
@@ -55,8 +70,6 @@ class DashboardFragment : BaseFragment(R.layout.fragment_list) {
 
         binding.toolbar.apply {
             setTitle(R.string.dashboard_title)
-            setNavigationIcon(R.drawable.ic_close)
-            setNavigationContentDescription(R.string.cd_close)
         }
 
         binding.content.adapter = adapter
@@ -78,9 +91,8 @@ class DashboardFragment : BaseFragment(R.layout.fragment_list) {
     }
 
     private fun navigateToDashboardItem(dashboardItemReference: DashboardItemRef) {
-        enterTransition = exitTransition
         findNavController().navigateCatchingErrors(
-            DashboardFragmentDirections.actionDashboardFragment(dashboardItemReference, true),
+            DashboardFragmentDirections.actionDashboardFragment(dashboardItemReference, fromDashboardItem = true),
             FragmentNavigatorExtras(binding.appbar to binding.appbar.transitionName)
         )
     }

--- a/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardOverviewFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/dashboard/DashboardOverviewFragment.kt
@@ -10,9 +10,10 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.navigation.navGraphViewModels
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
 import nl.rijksoverheid.en.BaseFragment
@@ -23,19 +24,33 @@ import nl.rijksoverheid.en.items.DashboardCardItem
 import nl.rijksoverheid.en.navigation.navigateCatchingErrors
 import nl.rijksoverheid.en.util.ext.setExitSlideTransition
 
+private const val KEY_NAVIGATED_TO_DASHBOARD_ITEM = "navigate_dashboard_item"
+
 class DashboardOverviewFragment : BaseFragment(R.layout.fragment_list) {
 
-    private val viewModel: DashboardViewModel by viewModels()
+    private val viewModel: DashboardViewModel by navGraphViewModels(
+        R.id.nav_dashboard,
+        factoryProducer = { defaultViewModelProviderFactory }
+    )
     private val adapter = GroupAdapter<GroupieViewHolder>()
     private val section = DashboardOverviewSection().also {
         adapter.add(it)
     }
 
+    private var navigatedToDashboardItem: Boolean = false
+
     private lateinit var binding: FragmentListBinding
+    private val args: DashboardOverviewFragmentArgs by navArgs()
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_NAVIGATED_TO_DASHBOARD_ITEM, navigatedToDashboardItem)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        navigatedToDashboardItem =
+            savedInstanceState?.getBoolean(KEY_NAVIGATED_TO_DASHBOARD_ITEM, false) ?: false
         setExitSlideTransition()
     }
 
@@ -45,8 +60,6 @@ class DashboardOverviewFragment : BaseFragment(R.layout.fragment_list) {
 
         binding.toolbar.apply {
             setTitle(R.string.dashboard_title)
-            setNavigationIcon(R.drawable.ic_close)
-            setNavigationContentDescription(R.string.cd_close)
         }
 
         binding.content.adapter = adapter
@@ -64,11 +77,27 @@ class DashboardOverviewFragment : BaseFragment(R.layout.fragment_list) {
                 is DashboardDataResult.Success -> section.updateDashboardData(requireContext(), result.data, ::navigateToMoreInfo)
             }
         }
+
+        val reference = args.dashboardItemReference?.let {
+            DashboardItemRef.valueOf(it)
+        }
+        if (reference != null && !navigatedToDashboardItem) {
+            navigatedToDashboardItem = true
+            findNavController().navigate(
+                DashboardFragmentDirections.actionDashboardFragment(
+                    reference,
+                    fromDeeplink = true
+                ),
+                FragmentNavigatorExtras(binding.appbar to binding.appbar.transitionName)
+            )
+        }
     }
 
     private fun navigateToDashboardItem(dashboardItemReference: DashboardItemRef) {
         findNavController().navigateCatchingErrors(
-            DashboardOverviewFragmentDirections.actionDashboardFragment(dashboardItemReference, true),
+            DashboardOverviewFragmentDirections.actionDashboardFragment(
+                dashboardItemReference
+            ),
             FragmentNavigatorExtras(binding.appbar to binding.appbar.transitionName)
         )
     }

--- a/app/src/main/java/nl/rijksoverheid/en/status/StatusFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/status/StatusFragment.kt
@@ -310,7 +310,7 @@ class StatusFragment @JvmOverloads constructor(
 
     private fun navigateToDashboardItem(dashboardItem: DashboardItem) {
         findNavController().navigateCatchingErrors(
-            StatusFragmentDirections.actionDashboard(dashboardItem.reference)
+            StatusFragmentDirections.actionDashboardOverview(dashboardItemReference = dashboardItem.reference.name)
         )
     }
 

--- a/app/src/main/res/navigation/nav_dashboard.xml
+++ b/app/src/main/res/navigation/nav_dashboard.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
+  ~   Licensed under the EUROPEAN UNION PUBLIC LICENCE v. 1.2
+  ~
+  ~   SPDX-License-Identifier: EUPL-1.2
+  ~
+  -->
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_dashboard"
+    app:startDestination="@id/dashboardOverviewFragment">
+
+    <fragment
+        android:id="@+id/dashboardOverviewFragment"
+        android:name="nl.rijksoverheid.en.dashboard.DashboardOverviewFragment"
+        android:label="DashboardOverviewFragment"
+        tools:layout="@layout/fragment_list" >
+        <argument
+            android:name="dashboardItemReference"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null" />
+        <action
+            android:id="@+id/action_dashboard_fragment"
+            app:destination="@id/dashboardFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/dashboardFragment"
+        android:name="nl.rijksoverheid.en.dashboard.DashboardFragment"
+        android:label="DashboardFragment"
+        tools:layout="@layout/fragment_list" >
+        <argument
+            android:name="dashboardItemReference"
+            app:argType="nl.rijksoverheid.en.api.model.DashboardItemRef" />
+        <argument
+            android:name="fromDeeplink"
+            app:argType="boolean"
+            android:defaultValue="false" />
+        <argument
+            android:name="fromDashboardItem"
+            app:argType="boolean"
+            android:defaultValue="false" />
+        <action
+            android:id="@+id/action_dashboard_fragment"
+            app:destination="@id/dashboardFragment"
+            app:popUpTo="@id/dashboardFragment"
+            app:popUpToInclusive="true"/>
+    </fragment>
+
+</navigation>

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -116,18 +116,17 @@
             app:popExitAnim="@anim/fragment_close_exit" />
         <action
             android:id="@+id/action_dashboard_overview"
-            app:destination="@id/dashboardOverviewFragment"
+            app:destination="@id/nav_dashboard"
             app:enterAnim="@anim/fragment_open_enter"
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit" />
-        <action
-            android:id="@+id/action_dashboard"
-            app:destination="@id/dashboardFragment"
-            app:enterAnim="@anim/fragment_open_enter"
-            app:exitAnim="@anim/fragment_open_exit"
-            app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit" />
+            app:popExitAnim="@anim/fragment_close_exit">
+            <argument
+                android:name="dashboardItemReference"
+                app:argType="string"
+                app:nullable="true"
+                android:defaultValue="@null" />
+        </action>
     </fragment>
 
     <fragment
@@ -412,37 +411,6 @@
             app:popUpToInclusive="false" />
     </dialog>
 
-    <fragment
-        android:id="@+id/dashboardOverviewFragment"
-        android:name="nl.rijksoverheid.en.dashboard.DashboardOverviewFragment"
-        android:label="DashboardOverviewFragment"
-        tools:layout="@layout/fragment_list" >
-        <action
-            android:id="@+id/action_dashboard_fragment"
-            app:destination="@id/dashboardFragment"
-            app:enterAnim="@anim/fragment_open_enter"
-            app:exitAnim="@anim/fragment_open_exit"
-            app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/dashboardFragment"
-        android:name="nl.rijksoverheid.en.dashboard.DashboardFragment"
-        android:label="DashboardFragment"
-        tools:layout="@layout/fragment_list" >
-        <argument
-            android:name="dashboardItemReference"
-            app:argType="nl.rijksoverheid.en.api.model.DashboardItemRef" />
-        <argument
-            android:name="showEnterTransition"
-            app:argType="boolean"
-            android:defaultValue="false" />
-        <action
-            android:id="@+id/action_dashboard_fragment"
-            app:destination="@id/dashboardFragment"
-            app:popUpTo="@id/dashboardFragment"
-            app:popUpToInclusive="true" />
-    </fragment>
+    <include app:graph="@navigation/nav_dashboard" />
 
 </navigation>

--- a/app/src/main/res/transition/short_fade.xml
+++ b/app/src/main/res/transition/short_fade.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2020 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
+  ~   Licensed under the EUROPEAN UNION PUBLIC LICENCE v. 1.2
+  ~
+  ~   SPDX-License-Identifier: EUPL-1.2
+  ~
+  -->
+
+<transitionSet xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_shortAnimTime"
+    android:transitionOrdering="together">
+    <fade />
+</transitionSet>

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ allprojects {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
                 jvmTarget = "1.8"
-                allWarningsAsErrors = true
             }
         }
 


### PR DESCRIPTION
Separate 3 cases for transition on DashboardFragment

* Deeplinking into a dashboard (graph)
* From dashboard to another one (replacing the screen)
* From the dashboard overview

When jumping into a graph from the StatusFragment, trampoline through the DashboardOverviewFragment. This seems to be needed to get the shared element (appbar) transition working correctly.

Navigation graph has been split so that the view model can be shared between the dashboard destinations without reloading the dashboard data every time (from network or cache).

# Before

https://user-images.githubusercontent.com/866834/185111007-187f20ff-da5e-4573-97ab-bee74c50f0c1.mp4

# After

https://user-images.githubusercontent.com/866834/185111046-1d5dd007-1e5c-45b8-890c-e0ffb1c74234.mp4


https://user-images.githubusercontent.com/866834/185111051-88c6fcc0-aa18-4db5-ad57-658391f7e34a.mp4

Ref https://github.com/minvws/nl-covid19-notification-app-coordination-private/issues/13
