### PR TITLE
Request notification permission on Android 13

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -39,8 +39,6 @@ android {
         }
 
         debug {
-            // Uncomment to disable pinning for all debug variants
-            // buildConfigField "boolean", "FEATURE_SSL_PINNING", "false"
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name="nl.rijksoverheid.en.EnApplication"

--- a/app/src/main/java/nl/rijksoverheid/en/onboarding/OnboardingHelper.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/onboarding/OnboardingHelper.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
+ *  Licensed under the EUROPEAN UNION PUBLIC LICENCE v. 1.2
+ *
+ *  SPDX-License-Identifier: EUPL-1.2
+ */
+package nl.rijksoverheid.en.onboarding
+
+import android.os.Build
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.LifecycleOwner
+import nl.rijksoverheid.en.ExposureNotificationsViewModel
+import nl.rijksoverheid.en.ignoreInitiallyEnabled
+import nl.rijksoverheid.en.util.launchDisableBatteryOptimizationsRequest
+
+class OnboardingHelper(fragment: Fragment) {
+    private val onboardingViewModel by fragment.activityViewModels<OnboardingViewModel>()
+    private val exposureNotificationsViewModel by fragment.activityViewModels<ExposureNotificationsViewModel>()
+    private val notificationsPermissionRequest =
+        fragment.registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            // always continue, the main screen has a warning
+            requestDisableBatteryOptimizations()
+        }
+
+    private val disableBatteryOptimizationsRequest =
+        fragment.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { onboardingViewModel.continueOnboarding() }
+
+    fun observeExposureNotificationsApiEnabled(viewLifecycleOwner: LifecycleOwner) {
+        exposureNotificationsViewModel.notificationState.ignoreInitiallyEnabled()
+            .observe(viewLifecycleOwner) {
+                if (it is ExposureNotificationsViewModel.NotificationsState.Enabled) {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        requestDisableBatteryOptimizations()
+                    } else {
+                        notificationsPermissionRequest.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                }
+            }
+    }
+
+    fun requestDisableBatteryOptimizations() {
+        disableBatteryOptimizationsRequest.launchDisableBatteryOptimizationsRequest { onboardingViewModel.continueOnboarding() }
+    }
+}

--- a/app/src/main/java/nl/rijksoverheid/en/util/BatteryOptimizationUtils.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/BatteryOptimizationUtils.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
@@ -36,10 +37,18 @@ fun Context.isIgnoringBatteryOptimizations(): Boolean {
 }
 
 private fun supportsRequestDisableBatteryOptimisations(context: Context): Boolean {
-    return context.packageManager.resolveActivity(
-        requestDisableBatteryOptimizationsIntent,
-        PackageManager.MATCH_DEFAULT_ONLY
-    ) != null
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("DEPRECATION")
+        context.packageManager.resolveActivity(
+            requestDisableBatteryOptimizationsIntent,
+            PackageManager.MATCH_DEFAULT_ONLY
+        )
+    } else {
+        context.packageManager.resolveActivity(
+            requestDisableBatteryOptimizationsIntent,
+            PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong())
+        )
+    } != null
 }
 
 fun ActivityResultLauncher<Intent>.launchDisableBatteryOptimizationsRequest(onActivityNotFound: () -> Unit = {}) {

--- a/app/src/test/java/nl/rijksoverheid/en/ExposureNotificationsRepositoryTest.kt
+++ b/app/src/test/java/nl/rijksoverheid/en/ExposureNotificationsRepositoryTest.kt
@@ -181,6 +181,7 @@ private val MOCK_RISK_CALCULATION_PARAMS = RiskCalculationParameters(
     reportTypeWhenMissing = ReportType.CONFIRMED_TEST
 )
 
+@Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 class ExposureNotificationsRepositoryTest {
     private lateinit var mockWebServer: MockWebServer

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ allprojects {
 
         project.plugins.withId("com.android.base") {
             android {
-                compileSdkVersion 32
+                compileSdkVersion 33
                 defaultConfig {
                     minSdkVersion 23
-                    targetSdkVersion 32
+                    targetSdkVersion 33
                 }
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_1_8

--- a/en-api/src/main/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApi.kt
+++ b/en-api/src/main/java/nl/rijksoverheid/en/enapi/nearby/NearbyExposureNotificationApi.kt
@@ -8,6 +8,8 @@ package nl.rijksoverheid.en.enapi.nearby
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.nearby.exposurenotification.DailySummariesConfig
@@ -222,10 +224,18 @@ class NearbyExposureNotificationApi(
     }
 
     private fun isApiAvailable(): Boolean {
-        return context.packageManager.resolveActivity(
-            Intent(ExposureNotificationClient.ACTION_EXPOSURE_NOTIFICATION_SETTINGS),
-            0
-        ) != null
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            @Suppress("DEPRECATION")
+            context.packageManager.resolveActivity(
+                Intent(ExposureNotificationClient.ACTION_EXPOSURE_NOTIFICATION_SETTINGS),
+                0
+            )
+        } else {
+            context.packageManager.resolveActivity(
+                Intent(ExposureNotificationClient.ACTION_EXPOSURE_NOTIFICATION_SETTINGS),
+                PackageManager.ResolveInfoFlags.of(0)
+            )
+        } != null
     }
 
     override fun deviceSupportsLocationlessScanning(): Boolean {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp = "7.2.1"
+agp = "7.2.2"
 androidx-activity = "1.5.1"
-androidx-appcompat = "1.4.2"
+androidx-appcompat = "1.5.0"
 androidx-arch-core = "2.1.0"
-androidx-fragment = "1.5.1"
+androidx-fragment = "1.5.2"
 androidx-navigation = "2.5.1"
 androidx-preference = "1.2.0"
 androidx-test = "1.4.0"
@@ -15,9 +15,9 @@ groupie = "2.10.1"
 # @pin update manually
 kotlin = "1.7.10"
 kotlin-coroutines = "1.6.4"
-mockito = "4.6.1"
+mockito = "4.7.0"
 moshi = "1.13.0"
-okhttp3 = "4.9.1"
+okhttp3 = "4.10.0"
 play-services = "18.1.0"
 retrofit2 = "2.9.0"
 
@@ -30,17 +30,16 @@ androidx-core = "androidx.core:core-ktx:1.8.0"
 androidx-core-splashscreen = "androidx.core:core-splashscreen:1.0.0-beta02"
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
-androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.4.1"
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.5.1"
 androidx-lifecycle-common-java8 = "androidx.lifecycle:lifecycle-common-java8:2.5.1"
-androidx-lifecycle-extensions = "androidx.lifecycle:lifecycle-extensions:2.2.0"
 androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
-androidx-lifecycle-livedata-core = "androidx.lifecycle:lifecycle-livedata-core-ktx:2.4.1"
+androidx-lifecycle-livedata-core = "androidx.lifecycle:lifecycle-livedata-core-ktx:2.5.1"
 androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.5.1"
-androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
 androidx-lifecycle-runtime-testing = "androidx.lifecycle:lifecycle-runtime-testing:2.3.1"
 androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.2.0"
 androidx-lifecycle-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
-androidx-lifecycle-viewmodel-savedstate = "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
+androidx-lifecycle-viewmodel-savedstate = "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1"
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidx-navigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
@@ -80,9 +79,9 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
-okhttp3-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.10.0"
-okhttp3-tls = "com.squareup.okhttp3:okhttp-tls:4.10.0"
-okio = "com.squareup.okio:okio:2.10.0"
+okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
+okhttp3-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp3" }
+okio = "com.squareup.okio:okio:3.0.0"
 play-core = "com.google.android.play:core:1.10.3"
 play-core-ktx = "com.google.android.play:core-ktx:1.8.1"
 playServices-base = { module = "com.google.android.gms:play-services-base", version.ref = "play-services" }
@@ -90,7 +89,7 @@ playServices-basement = { module = "com.google.android.gms:play-services-basemen
 playServices-tasks = "com.google.android.gms:play-services-tasks:18.0.2"
 retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
 retrofit2-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit2" }
-robolectric = "org.robolectric:robolectric:4.8.1"
+robolectric = "org.robolectric:robolectric:4.8.2"
 timber = "com.jakewharton.timber:timber:5.0.1"
 tink-android = "com.google.crypto.tink:tink-android:1.5.0"
 
@@ -117,7 +116,7 @@ playServices = [
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-firebase-appdistribution = "com.google.firebase.appdistribution:3.0.2"
+firebase-appdistribution = "com.google.firebase.appdistribution:3.0.3"
 fladle = "com.osacky.fladle:0.17.4"
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -125,7 +124,7 @@ kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 # @pin to kotlin version
 ksp = "com.google.devtools.ksp:1.7.10-1.0.6"
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
-spotless = "com.diffplug.spotless:6.9.0"
+spotless = "com.diffplug.spotless:6.10.0"
 tripletPlay = "com.github.triplet.play:3.7.0"
-versionCatalog = "nl.littlerobots.version-catalog-update:0.5.3"
+versionCatalog = "nl.littlerobots.version-catalog-update:0.6.1"
 versions = "com.github.ben-manes.versions:0.42.0"


### PR DESCRIPTION
Bump target SDK to Android 13 and handle requesting the permission in onboarding and the main status screen.

Fixes https://github.com/minvws/nl-covid19-notification-app-coordination-private/issues/27