### PR TITLE
Use supported API for changing locale

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/EnApplication.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/EnApplication.kt
@@ -15,7 +15,6 @@ import androidx.work.WorkManager
 import nl.rijksoverheid.en.beagle.debugDrawer
 import nl.rijksoverheid.en.job.EnWorkerFactory
 import nl.rijksoverheid.en.notifier.NotificationsRepository
-import nl.rijksoverheid.en.util.LocaleHelper
 import timber.log.Timber
 
 @Suppress("ConstantConditionIf")
@@ -25,7 +24,6 @@ class EnApplication : Application(), Configuration.Provider {
     @SuppressLint("RestrictedApi") // for WM Logger api
     override fun onCreate() {
         super.onCreate()
-        LocaleHelper.initialize(this)
 
         if (BuildConfig.FEATURE_LOGGING) {
             Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/MainActivity.kt
@@ -31,6 +31,7 @@ import nl.rijksoverheid.en.job.RemindExposureNotificationWorker
 import nl.rijksoverheid.en.lifecyle.EventObserver
 import nl.rijksoverheid.en.navigation.isInitialised
 import nl.rijksoverheid.en.notifier.NotificationsRepository
+import nl.rijksoverheid.en.util.LocaleHelper
 import timber.log.Timber
 
 private const val TAG_GENERIC_ERROR = "generic_error"
@@ -50,6 +51,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
+        LocaleHelper(this).applyLocale()
         super.onCreate(savedInstanceState)
 
         splashScreen.setKeepOnScreenCondition {

--- a/app/src/main/java/nl/rijksoverheid/en/job/EnWorkerFactory.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/job/EnWorkerFactory.kt
@@ -14,6 +14,7 @@ import nl.rijksoverheid.en.factory.RepositoryFactory.createExposureNotifications
 import nl.rijksoverheid.en.factory.RepositoryFactory.createLabTestRepository
 import nl.rijksoverheid.en.factory.RepositoryFactory.createSettingsRepository
 import nl.rijksoverheid.en.notifier.NotificationsRepository
+import nl.rijksoverheid.en.util.withAppLocale
 
 /**
  * Factory for CoroutineWorkers classes.
@@ -29,20 +30,20 @@ class EnWorkerFactory : WorkerFactory() {
                 appContext,
                 workerParameters,
                 createExposureNotificationsRepository(appContext),
-                NotificationsRepository(appContext)
+                createNotificationsRepository(appContext)
             )
             CheckConnectionWorker::class.java.name -> CheckConnectionWorker(
                 appContext,
                 workerParameters,
                 createExposureNotificationsRepository(appContext),
-                NotificationsRepository(appContext),
+                createNotificationsRepository(appContext),
                 createSettingsRepository(appContext)
             )
             ExposureNotificationJob::class.java.name -> ExposureNotificationJob(
                 appContext,
                 workerParameters,
                 createExposureNotificationsRepository(appContext),
-                NotificationsRepository(appContext)
+                createNotificationsRepository(appContext)
             )
             UploadDiagnosisKeysJob::class.java.name -> UploadDiagnosisKeysJob(
                 appContext,
@@ -63,7 +64,7 @@ class EnWorkerFactory : WorkerFactory() {
                 appContext,
                 workerParameters,
                 createExposureNotificationsRepository(appContext),
-                NotificationsRepository(appContext)
+                createNotificationsRepository(appContext)
             )
             ExposureCleanupWorker::class.java.name -> ExposureCleanupWorker(
                 appContext,
@@ -73,4 +74,7 @@ class EnWorkerFactory : WorkerFactory() {
             else -> null
         }
     }
+
+    private fun createNotificationsRepository(context: Context) =
+        NotificationsRepository(context.withAppLocale())
 }

--- a/app/src/main/java/nl/rijksoverheid/en/settings/ExposureNotificationsPausedReminderReceiver.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/settings/ExposureNotificationsPausedReminderReceiver.kt
@@ -12,6 +12,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import nl.rijksoverheid.en.notifier.NotificationsRepository
+import nl.rijksoverheid.en.util.withAppLocale
 import timber.log.Timber
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -22,7 +23,7 @@ import java.time.ZoneId
 class ExposureNotificationsPausedReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         Timber.d("onReceive")
-        NotificationsRepository(context).showAppPausedReminder()
+        NotificationsRepository(context.withAppLocale()).showAppPausedReminder()
     }
 
     companion object {

--- a/app/src/main/java/nl/rijksoverheid/en/settings/SettingsFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/settings/SettingsFragment.kt
@@ -32,7 +32,9 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
     private val viewModel: ExposureNotificationsViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by viewModels()
 
-    private val localeHelper = LocaleHelper.getInstance()
+    private val localeHelper by lazy {
+        LocaleHelper(requireContext())
+    }
 
     private lateinit var binding: FragmentSettingsBinding
 
@@ -47,10 +49,8 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
         binding.isSystemLanguageDutch = localeHelper.isSystemLanguageDutch
         binding.useAppInDutchSwitch.isChecked = localeHelper.isAppSetToDutch
         binding.useAppInDutchSwitch.setOnCheckedChangeListener { _, isChecked ->
-            if (localeHelper.useAppInDutch(isChecked, requireContext())) {
-                // Ensure current fragment is updated after changing language
-                parentFragmentManager.beginTransaction().detach(this).commitAllowingStateLoss()
-                parentFragmentManager.beginTransaction().attach(this).commitAllowingStateLoss()
+            if (localeHelper.isAppSetToDutch != isChecked) {
+                localeHelper.useAppInDutch(isChecked)
             }
         }
 

--- a/app/src/main/java/nl/rijksoverheid/en/util/LocaleHelper.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/util/LocaleHelper.kt
@@ -6,95 +6,78 @@
  */
 package nl.rijksoverheid.en.util
 
-import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
-import android.content.res.Resources
-import androidx.core.os.ConfigurationCompat
+import android.os.Build
+import android.os.LocaleList
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.app.LocaleManagerCompat
 import androidx.core.os.LocaleListCompat
 import nl.rijksoverheid.en.settings.Settings
 import java.util.Locale
 
+private val DUTCH_LOCALE = Locale("nl", "NL")
+
 /**
  * Helper class for applying the correct language based on the system or in app setting.
  */
-class LocaleHelper private constructor(application: Application, private val settings: Settings) {
-
-    // Ensure systemLocale is set and ConfigurationChangedCallback is registered _before_
-    // custom Locale is applied, as the system locale can not be reliably retrieved after
-    // changing the app's Locale.
-    private var systemLocale: Locale = requireNotNull(LocaleListCompat.getDefault()[0])
+class LocaleHelper constructor(
+    private val context: Context,
+    private val settings: Settings = Settings(context),
+    /* for testing */
+    private val setApplicationLocales: (LocaleListCompat) -> Unit = { AppCompatDelegate.setApplicationLocales(it) }
+) {
+    private val systemLocale: Locale = LocaleManagerCompat.getSystemLocales(context)[0] ?: Locale.getDefault()
 
     val isAppSetToDutch: Boolean
         get() = settings.isAppSetToDutch
 
     val isSystemLanguageDutch
-        get() = systemLocale == dutchLocale
+        get() = systemLocale.language == DUTCH_LOCALE.language
 
-    private val localeToUse: Locale
-        get() = if (isAppSetToDutch) dutchLocale else systemLocale
-
-    init {
-        application.registerActivityLifecycleCallbacks(
-            ActivityCreatedCallback { activity ->
-                applyLocale(activity, localeToUse)
-            }
-        )
-
-        application.registerComponentCallbacks(
-            ConfigurationChangedCallback { configuration ->
-                systemLocale = requireNotNull(ConfigurationCompat.getLocales(configuration)[0])
-                applyLocale(application, localeToUse)
-            }
-        )
-        applyLocale(application, localeToUse)
+    fun useAppInDutch(useAppInDutch: Boolean) {
+        settings.isAppSetToDutch = useAppInDutch
+        applyLocale()
     }
 
-    fun useAppInDutch(useAppInDutch: Boolean, context: Context): Boolean {
-        return if (useAppInDutch != isAppSetToDutch) {
-            settings.isAppSetToDutch = useAppInDutch
-            applyLocale(context, localeToUse)
-            true
+    fun applyLocale() {
+        if (isAppSetToDutch) {
+            setApplicationLocales(LocaleListCompat.create(DUTCH_LOCALE))
         } else {
-            false
+            setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
         }
     }
 
-    private fun applyLocale(context: Context, locale: Locale) {
-        updateResources(context.resources, locale)
-        val appContext = context.applicationContext
-        if (appContext !== context) {
-            updateResources(appContext.resources, locale)
+    /**
+     * Wraps a context with the appropriate locale, based on [isAppSetToDutch]
+     * This is only required for notifications where AppCompateDelegate does not affect
+     * the context. On Android 13 and up this method is a no-op as locale changes
+     * are handled by the system in that case.
+     *
+     * @param context the context to set the locale configuration on
+     * @return a context with the configured locale
+     */
+    fun createContextForLocale(context: Context): Context {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context
+        } else {
+            context.createConfigurationContext(updateConfiguration(context.resources.configuration))
         }
     }
 
-    @Suppress("DEPRECATION")
-    private fun updateResources(resources: Resources, locale: Locale) {
-        val currentLocale = ConfigurationCompat.getLocales(resources.configuration)[0]
-        if (currentLocale == locale) return
-        Locale.setDefault(locale)
-        resources.apply {
-            val config = Configuration(configuration).apply {
-                setLocale(locale)
+    private fun updateConfiguration(configuration: Configuration): Configuration {
+        val updatedConfig = Configuration(configuration)
+        if (isAppSetToDutch) {
+            updatedConfig.setLocale(DUTCH_LOCALE)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                updatedConfig.setLocales(LocaleList(DUTCH_LOCALE))
             }
-            updateConfiguration(config, displayMetrics)
         }
-    }
-
-    companion object {
-
-        val dutchLocale: Locale = Locale("nl", "NL")
-
-        private lateinit var localeHelper: LocaleHelper
-
-        fun initialize(application: Application) {
-            check(!::localeHelper.isInitialized) { "LocaleHelper was already initialized." }
-            localeHelper = LocaleHelper(application, Settings(application))
-        }
-
-        fun getInstance(): LocaleHelper {
-            check(::localeHelper.isInitialized) { "LocaleHelper was not initialized. Ensure it is initialized in Application.onCreate." }
-            return localeHelper
-        }
+        return updatedConfig
     }
 }
+
+/**
+ * Applies the app locale using [LocaleHelper.createContextForLocale]
+ */
+fun Context.withAppLocale(): Context = LocaleHelper(this).createContextForLocale(this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "7.2.2"
 androidx-activity = "1.5.1"
-androidx-appcompat = "1.5.0"
+androidx-appcompat = "1.6.0-beta01"
 androidx-arch-core = "2.1.0"
 androidx-fragment = "1.5.2"
 androidx-navigation = "2.5.1"


### PR DESCRIPTION
* Use AppCompatDelegate and Android 13 compat APIs to override the app locale if set to Dutch
* Use createConfigurationContext to explicitly create a context suitable for notifications
* Remove magic hooks that try to update the config on contexts in place
* Remove attach/detach logic in fragment, it's no longer needed as the activity is restarted correctly
* Simplify LocaleHelper, it no longer needs to be a singleton instance

Fixes https://github.com/minvws/nl-covid19-notification-app-coordination-private/issues/29